### PR TITLE
ci: fix test logger by adding GitHubActionsTestLogger package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           dotnet test hangfire-mcp-dotnet.slnx
           --configuration Release --no-build
           --logger "trx"
-          --logger "GitHubActions"
+          --logger "GitHubActions;summary.includePassedTests=false;summary.includeSkippedTests=true"
           --results-directory ./Artefacts
           --collect:"XPlat Code Coverage"
         shell: pwsh

--- a/tests/Nall.Hangfire.Mcp.Tests/Nall.Hangfire.Mcp.Tests.csproj
+++ b/tests/Nall.Hangfire.Mcp.Tests/Nall.Hangfire.Mcp.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />


### PR DESCRIPTION
## Summary
- The `GitHubActions` test logger isn't built into the .NET SDK; the workflow's `--logger \"GitHubActions\"` flag failed with *"Could not find a test logger ... 'GitHubActions'"*, breaking `Build` on `main` after the initial commit.
- Adds the `GitHubActionsTestLogger` (v2.4.1) PackageReference to the test project so the logger resolves, and tunes its summary options.
- Result: failing tests will surface as inline GitHub annotations on PR diffs.

## Test plan
- [x] `dotnet test --logger "GitHubActions"` resolves the logger locally and 34/34 pass.
- [ ] CI green on this PR.