### PR TITLE
feat: built-in hangfire_* maintenance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,36 @@ To populate the manifest, install the generator package in each project that con
 dotnet add package Nall.Hangfire.Mcp.Generator
 ```
 
+## Built-in maintenance tools
+
+Every MCP server hosted by `AddHangfireMcp()` also exposes a fixed set of `hangfire_*` tools for inspecting and managing jobs alongside the dynamic `Run_*` tools:
+
+| Tool                      | Purpose                                                                                            |
+| ------------------------- | -------------------------------------------------------------------------------------------------- |
+| `hangfire_get_statistics` | Global counters: Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries/Servers. |
+| `hangfire_list_queues`    | Per-queue length + sample of first enqueued jobs.                                                  |
+| `hangfire_list_jobs`      | Page jobs by `state` with optional filter. Use this to discover ids before bulk ops.               |
+| `hangfire_get_job`        | Full details + state history for one id.                                                           |
+| `hangfire_delete_job`     | Move one job to Deleted.                                                                           |
+| `hangfire_requeue_job`    | Requeue one job (covers retry of Failed).                                                          |
+| `hangfire_delete_jobs`    | Bulk delete by `ids` **or** `filter` (exactly one).                                                |
+| `hangfire_requeue_jobs`   | Bulk requeue by `ids` **or** `filter`.                                                             |
+
+Filter shape (used by `list_jobs`, `delete_jobs`, `requeue_jobs`):
+
+```json
+{
+  "state": "Failed",
+  "queue": "default",
+  "jobType": "ReportJob",
+  "method": "Generate",
+  "messageContains": "timeout",
+  "exceptionContains": "SqlException"
+}
+```
+
+`jobType` and `method` are case-insensitive substring matches. `messageContains` / `exceptionContains` are most useful for `Failed`.
+
 ## Parameter binding
 
 For each tool call:

--- a/src/Nall.Hangfire.Mcp.Generator/HangfireRegistrationGenerator.cs
+++ b/src/Nall.Hangfire.Mcp.Generator/HangfireRegistrationGenerator.cs
@@ -10,7 +10,7 @@ namespace Nall.Hangfire.Mcp.Generator;
 [Generator(LanguageNames.CSharp)]
 public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
 {
-    private static readonly HashSet<string> RegistrationMethodNames = new(
+    private static readonly HashSet<string> s_registrationMethodNames = new(
         System.StringComparer.Ordinal
     )
     {
@@ -21,7 +21,7 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         "ContinueWith",
     };
 
-    private static readonly HashSet<string> HangfireContainingTypes = new(
+    private static readonly HashSet<string> s_hangfireContainingTypes = new(
         System.StringComparer.Ordinal
     )
     {
@@ -82,7 +82,7 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         {
             return false;
         }
-        return RegistrationMethodNames.Contains(name);
+        return s_registrationMethodNames.Contains(name);
     }
 
     private static Entry? Extract(GeneratorSyntaxContext ctx)
@@ -97,7 +97,7 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         }
 
         var containing = method.ContainingType?.ToDisplayString();
-        if (containing is null || !HangfireContainingTypes.Contains(containing))
+        if (containing is null || !s_hangfireContainingTypes.Contains(containing))
         {
             return null;
         }

--- a/src/Nall.Hangfire.Mcp/HangfireMcpHandlers.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpHandlers.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Maintenance;
 
 namespace Nall.Hangfire.Mcp;
 
@@ -7,19 +8,36 @@ public static class HangfireMcpHandlers
     public static ListToolsResult BuildListToolsResult(JobCatalog catalog)
     {
         ArgumentNullException.ThrowIfNull(catalog);
-        return catalog.ListToolsResult;
+        var tools = new List<Tool>(
+            catalog.ListToolsResult.Tools.Count + MaintenanceTools.All.Count
+        );
+        tools.AddRange(MaintenanceTools.All);
+        foreach (var t in catalog.ListToolsResult.Tools)
+        {
+            if (!MaintenanceTools.IsMaintenance(t.Name))
+            {
+                tools.Add(t);
+            }
+        }
+        return new ListToolsResult { Tools = tools };
     }
 
     public static CallToolResult InvokeTool(
         JobCatalog catalog,
         HangfireDynamicScheduler scheduler,
+        MaintenanceDispatcher maintenance,
         CallToolRequestParams? @params
     )
     {
         ArgumentNullException.ThrowIfNull(catalog);
         ArgumentNullException.ThrowIfNull(scheduler);
+        ArgumentNullException.ThrowIfNull(maintenance);
 
         var name = @params?.Name;
+        if (MaintenanceTools.IsMaintenance(name))
+        {
+            return maintenance.Invoke(@params);
+        }
         if (name is null || !catalog.TryGetByToolName(name, out var descriptor))
         {
             return Error($"Unknown tool '{name}'.");

--- a/src/Nall.Hangfire.Mcp/HangfireMcpOptions.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpOptions.cs
@@ -7,4 +7,6 @@ public sealed class HangfireMcpOptions
     public JobDiscoverySources Sources { get; set; } = JobDiscoverySources.RecurringStorage;
 
     public Func<RecurringJobDto, bool>? Filter { get; set; }
+
+    public int MaintenanceMaxBulkSize { get; set; } = 100;
 }

--- a/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 using Hangfire;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nall.Hangfire.Mcp;
 using Nall.Hangfire.Mcp.Maintenance;

--- a/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using Hangfire;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Nall.Hangfire.Mcp;
+using Nall.Hangfire.Mcp.Maintenance;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -26,6 +27,15 @@ public static class HangfireMcpServiceCollectionExtensions
         services.TryAddSingleton<HangfireDynamicScheduler>(sp => new HangfireDynamicScheduler(
             sp.GetRequiredService<IBackgroundJobClient>()
         ));
+        services.TryAddSingleton(sp => new MaintenanceQueryService(
+            sp.GetRequiredService<JobStorage>()
+        ));
+        services.TryAddSingleton(sp => new MaintenanceCommandService(
+            sp.GetRequiredService<IBackgroundJobClient>(),
+            sp.GetRequiredService<MaintenanceQueryService>(),
+            options.MaintenanceMaxBulkSize
+        ));
+        services.TryAddSingleton<MaintenanceDispatcher>();
 
         return services
             .AddMcpServer()
@@ -43,8 +53,14 @@ public static class HangfireMcpServiceCollectionExtensions
                     var catalog = request.Services!.GetRequiredService<JobCatalog>();
                     var scheduler =
                         request.Services!.GetRequiredService<HangfireDynamicScheduler>();
+                    var maintenance = request.Services!.GetRequiredService<MaintenanceDispatcher>();
                     return ValueTask.FromResult(
-                        HangfireMcpHandlers.InvokeTool(catalog, scheduler, request.Params)
+                        HangfireMcpHandlers.InvokeTool(
+                            catalog,
+                            scheduler,
+                            maintenance,
+                            request.Params
+                        )
                     );
                 }
             );

--- a/src/Nall.Hangfire.Mcp/Maintenance/JobFilter.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/JobFilter.cs
@@ -1,0 +1,21 @@
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public enum JobStateKind
+{
+    Enqueued,
+    Processing,
+    Scheduled,
+    Failed,
+    Succeeded,
+    Deleted,
+}
+
+public sealed record JobFilter
+{
+    public JobStateKind State { get; init; }
+    public string? Queue { get; init; }
+    public string? JobType { get; init; }
+    public string? Method { get; init; }
+    public string? MessageContains { get; init; }
+    public string? ExceptionContains { get; init; }
+}

--- a/src/Nall.Hangfire.Mcp/Maintenance/JobFilterMatcher.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/JobFilterMatcher.cs
@@ -1,0 +1,55 @@
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public static class JobFilterMatcher
+{
+    public static bool Matches(JobMatch match, JobFilter filter)
+    {
+        if (
+            filter.Queue is { } q
+            && !string.Equals(match.Queue, q, StringComparison.OrdinalIgnoreCase)
+        )
+        {
+            return false;
+        }
+
+        var job = match.Job;
+        if (filter.JobType is { } t)
+        {
+            var typeName = job?.Type?.FullName ?? job?.Type?.Name;
+            if (typeName is null || typeName.IndexOf(t, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return false;
+            }
+        }
+
+        if (filter.Method is { } m)
+        {
+            var methodName = job?.Method?.Name;
+            if (methodName is null || methodName.IndexOf(m, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                return false;
+            }
+        }
+
+        if (filter.MessageContains is { } msg)
+        {
+            if (!ContainsCi(match.Reason, msg) && !ContainsCi(match.ExceptionMessage, msg))
+            {
+                return false;
+            }
+        }
+
+        if (filter.ExceptionContains is { } ex)
+        {
+            if (!ContainsCi(match.ExceptionType, ex) && !ContainsCi(match.ExceptionMessage, ex))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsCi(string? haystack, string needle) =>
+        haystack is not null && haystack.IndexOf(needle, StringComparison.OrdinalIgnoreCase) >= 0;
+}

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceCommandService.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceCommandService.cs
@@ -1,0 +1,126 @@
+using Hangfire;
+
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public sealed class MaintenanceCommandService
+{
+    private readonly IBackgroundJobClient _client;
+    private readonly MaintenanceQueryService _query;
+    private readonly int _maxBulkSize;
+
+    public MaintenanceCommandService(
+        IBackgroundJobClient client,
+        MaintenanceQueryService query,
+        int maxBulkSize
+    )
+    {
+        ArgumentNullException.ThrowIfNull(client);
+        ArgumentNullException.ThrowIfNull(query);
+        if (maxBulkSize <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxBulkSize));
+        }
+        _client = client;
+        _query = query;
+        _maxBulkSize = maxBulkSize;
+    }
+
+    public int MaxBulkSize => _maxBulkSize;
+
+    public OpResult DeleteOne(string id) => RunOne(id, _client.Delete);
+
+    public OpResult RequeueOne(string id) => RunOne(id, _client.Requeue);
+
+    public BulkResult DeleteMany(
+        IReadOnlyCollection<string>? ids,
+        JobFilter? filter,
+        bool dryRun
+    ) => RunMany(ids, filter, dryRun, _client.Delete);
+
+    public BulkResult RequeueMany(
+        IReadOnlyCollection<string>? ids,
+        JobFilter? filter,
+        bool dryRun
+    ) => RunMany(ids, filter, dryRun, _client.Requeue);
+
+    private static OpResult RunOne(string id, Func<string, bool> op)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(id);
+        try
+        {
+            var ok = op(id);
+            return new OpResult(id, ok, null);
+        }
+        catch (Exception ex)
+        {
+            return new OpResult(id, false, ex.Message);
+        }
+    }
+
+    private BulkResult RunMany(
+        IReadOnlyCollection<string>? ids,
+        JobFilter? filter,
+        bool dryRun,
+        Func<string, bool> op
+    )
+    {
+        var bothNull = ids is null && filter is null;
+        var bothSet = ids is not null && filter is not null;
+        if (bothNull || bothSet)
+        {
+            throw new ArgumentException("Provide exactly one of 'ids' or 'filter'.");
+        }
+
+        IReadOnlyList<string> targets;
+        var truncated = false;
+        var scanned = 0;
+        long stateTotal = 0;
+
+        if (ids is not null)
+        {
+            if (ids.Count > _maxBulkSize)
+            {
+                throw new ArgumentException(
+                    $"ids count {ids.Count} exceeds MaintenanceMaxBulkSize {_maxBulkSize}."
+                );
+            }
+            targets = ids.ToArray();
+        }
+        else
+        {
+            var scan = _query.ScanByFilter(filter!, _maxBulkSize);
+            targets = scan.Matches.Select(m => m.Id).ToArray();
+            truncated = scan.Truncated;
+            scanned = scan.Scanned;
+            stateTotal = scan.StateTotal;
+        }
+
+        if (dryRun)
+        {
+            return new BulkResult(
+                targets.Select(id => new OpResult(id, true, null)).ToArray(),
+                DryRun: true,
+                Truncated: truncated,
+                Scanned: scanned,
+                StateTotal: stateTotal
+            );
+        }
+
+        var results = new List<OpResult>(targets.Count);
+        foreach (var id in targets)
+        {
+            results.Add(RunOne(id, op));
+        }
+        return new BulkResult(results, DryRun: false, truncated, scanned, stateTotal);
+    }
+}
+
+public sealed record OpResult(string Id, bool Ok, string? Error);
+
+public sealed record BulkResult(
+    IReadOnlyList<OpResult> Results,
+    bool DryRun,
+    bool Truncated,
+    int Scanned,
+    long StateTotal
+);

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
@@ -1,0 +1,274 @@
+using System.Text.Json;
+using ModelContextProtocol.Protocol;
+
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public sealed class MaintenanceDispatcher
+{
+    private static readonly JsonSerializerOptions s_json = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = false,
+    };
+
+    private readonly MaintenanceQueryService _query;
+    private readonly MaintenanceCommandService _commands;
+
+    public MaintenanceDispatcher(MaintenanceQueryService query, MaintenanceCommandService commands)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(commands);
+        _query = query;
+        _commands = commands;
+    }
+
+    public CallToolResult Invoke(CallToolRequestParams? @params)
+    {
+        var name = @params?.Name;
+        if (name is null)
+        {
+            return Error("Missing tool name.");
+        }
+
+        try
+        {
+            var args = @params?.Arguments?.AsReadOnly();
+            return name switch
+            {
+                MaintenanceTools.GetStatistics => Json(ProjectStatistics(_query.GetStatistics())),
+                MaintenanceTools.ListQueues => Json(ProjectQueues(_query.ListQueues())),
+                MaintenanceTools.ListJobs => HandleListJobs(args),
+                MaintenanceTools.GetJob => HandleGetJob(args),
+                MaintenanceTools.DeleteJob => HandleDeleteJob(args),
+                MaintenanceTools.RequeueJob => HandleRequeueJob(args),
+                MaintenanceTools.DeleteJobs => HandleBulk(args, delete: true),
+                MaintenanceTools.RequeueJobs => HandleBulk(args, delete: false),
+                _ => Error($"Unknown maintenance tool '{name}'."),
+            };
+        }
+        catch (Exception ex)
+            when (ex is ArgumentException or InvalidOperationException or JsonException)
+        {
+            return Error(ex.Message);
+        }
+    }
+
+    private CallToolResult HandleListJobs(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        var state =
+            ReadEnum<JobStateKind>(args, "state")
+            ?? throw new ArgumentException("'state' is required.");
+        var filter = ReadFilter(args, "filter", state);
+        var from = ReadInt(args, "from") ?? 0;
+        var count = ReadInt(args, "count") ?? 50;
+        if (count is < 1 or > 100)
+        {
+            throw new ArgumentException("'count' must be between 1 and 100.");
+        }
+        var scan = _query.ListJobs(state, filter, from, count);
+        return Json(
+            new
+            {
+                scan.Scanned,
+                scan.StateTotal,
+                scan.Truncated,
+                scan.NextFrom,
+                Jobs = scan.Matches.Select(ProjectMatch).ToArray(),
+            }
+        );
+    }
+
+    private CallToolResult HandleGetJob(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        var id = ReadString(args, "id") ?? throw new ArgumentException("'id' is required.");
+        var dto = _query.GetJob(id);
+        if (dto is null)
+        {
+            return Error($"Job '{id}' not found.");
+        }
+        return Json(
+            new
+            {
+                Id = id,
+                Type = dto.Job?.Type?.FullName,
+                Method = dto.Job?.Method?.Name,
+                Args = dto.Job?.Args,
+                Properties = dto.Properties,
+                ExpireAt = dto.ExpireAt,
+                CreatedAt = dto.CreatedAt,
+                History = dto
+                    .History.Select(h => new
+                    {
+                        h.StateName,
+                        h.Reason,
+                        h.CreatedAt,
+                        h.Data,
+                    })
+                    .ToArray(),
+            }
+        );
+    }
+
+    private CallToolResult HandleDeleteJob(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        var id = ReadString(args, "id") ?? throw new ArgumentException("'id' is required.");
+        return Json(_commands.DeleteOne(id));
+    }
+
+    private CallToolResult HandleRequeueJob(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        var id = ReadString(args, "id") ?? throw new ArgumentException("'id' is required.");
+        return Json(_commands.RequeueOne(id));
+    }
+
+    private CallToolResult HandleBulk(IReadOnlyDictionary<string, JsonElement>? args, bool delete)
+    {
+        var ids = ReadStringArray(args, "ids");
+        var filter = ReadFilter(args, "filter", state: null);
+        var dryRun = ReadBool(args, "dryRun") ?? false;
+        var result = delete
+            ? _commands.DeleteMany(ids, filter, dryRun)
+            : _commands.RequeueMany(ids, filter, dryRun);
+        return Json(result);
+    }
+
+    private static JobFilter? ReadFilter(
+        IReadOnlyDictionary<string, JsonElement>? args,
+        string key,
+        JobStateKind? state
+    )
+    {
+        if (
+            args is null
+            || !args.TryGetValue(key, out var el)
+            || el.ValueKind is not JsonValueKind.Object
+        )
+        {
+            return null;
+        }
+        var filterState =
+            ReadEnum<JobStateKind>(el, "state")
+            ?? state
+            ?? throw new ArgumentException("'filter.state' is required.");
+        return new JobFilter
+        {
+            State = filterState,
+            Queue = ReadStringProp(el, "queue"),
+            JobType = ReadStringProp(el, "jobType"),
+            Method = ReadStringProp(el, "method"),
+            MessageContains = ReadStringProp(el, "messageContains"),
+            ExceptionContains = ReadStringProp(el, "exceptionContains"),
+        };
+    }
+
+    private static string? ReadString(IReadOnlyDictionary<string, JsonElement>? args, string key) =>
+        args is not null && args.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static string? ReadStringProp(JsonElement obj, string key) =>
+        obj.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
+            ? v.GetString()
+            : null;
+
+    private static int? ReadInt(IReadOnlyDictionary<string, JsonElement>? args, string key) =>
+        args is not null && args.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.Number
+            ? v.GetInt32()
+            : null;
+
+    private static bool? ReadBool(IReadOnlyDictionary<string, JsonElement>? args, string key)
+    {
+        if (args is null || !args.TryGetValue(key, out var v))
+        {
+            return null;
+        }
+        return v.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => null,
+        };
+    }
+
+    private static IReadOnlyCollection<string>? ReadStringArray(
+        IReadOnlyDictionary<string, JsonElement>? args,
+        string key
+    )
+    {
+        if (args is null || !args.TryGetValue(key, out var v) || v.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+        var list = new List<string>(v.GetArrayLength());
+        foreach (var item in v.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String)
+            {
+                list.Add(item.GetString()!);
+            }
+        }
+        return list;
+    }
+
+    private static T? ReadEnum<T>(IReadOnlyDictionary<string, JsonElement>? args, string key)
+        where T : struct, Enum =>
+        ReadString(args, key) is { } s && Enum.TryParse<T>(s, ignoreCase: true, out var v)
+            ? v
+            : null;
+
+    private static T? ReadEnum<T>(JsonElement obj, string key)
+        where T : struct, Enum =>
+        ReadStringProp(obj, key) is { } s && Enum.TryParse<T>(s, ignoreCase: true, out var v)
+            ? v
+            : null;
+
+    private static object ProjectStatistics(global::Hangfire.Storage.Monitoring.StatisticsDto s) =>
+        new
+        {
+            s.Servers,
+            s.Queues,
+            s.Enqueued,
+            s.Failed,
+            s.Processing,
+            s.Scheduled,
+            s.Succeeded,
+            s.Deleted,
+            s.Recurring,
+            s.Retries,
+        };
+
+    private static object ProjectQueues(
+        IList<global::Hangfire.Storage.Monitoring.QueueWithTopEnqueuedJobsDto> queues
+    ) =>
+        queues
+            .Select(q => new
+            {
+                q.Name,
+                q.Length,
+                q.Fetched,
+                FirstJobs = q
+                    .FirstJobs.Select(j => new { Id = j.Key, Type = j.Value.Job?.Type?.FullName })
+                    .ToArray(),
+            })
+            .ToArray();
+
+    private static object ProjectMatch(JobMatch m) =>
+        new
+        {
+            m.Id,
+            Type = m.Job?.Type?.FullName,
+            Method = m.Job?.Method?.Name,
+            m.Queue,
+            m.Reason,
+            m.ExceptionType,
+            m.ExceptionMessage,
+        };
+
+    private static CallToolResult Json(object payload) =>
+        new()
+        {
+            Content = [new TextContentBlock { Text = JsonSerializer.Serialize(payload, s_json) }],
+        };
+
+    private static CallToolResult Error(string message) =>
+        new() { Content = [new TextContentBlock { Text = message }], IsError = true };
+}

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
@@ -1,0 +1,196 @@
+using Hangfire;
+using Hangfire.Common;
+using Hangfire.Storage;
+using Hangfire.Storage.Monitoring;
+
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public sealed class MaintenanceQueryService
+{
+    private const int PageSize = 1000;
+
+    private readonly JobStorage _storage;
+
+    public MaintenanceQueryService(JobStorage storage)
+    {
+        ArgumentNullException.ThrowIfNull(storage);
+        _storage = storage;
+    }
+
+    private IMonitoringApi Api => _storage.GetMonitoringApi();
+
+    public StatisticsDto GetStatistics() => Api.GetStatistics();
+
+    public IList<QueueWithTopEnqueuedJobsDto> ListQueues() => Api.Queues();
+
+    public JobDetailsDto? GetJob(string id) => Api.JobDetails(id);
+
+    public ScanResult ListJobs(JobStateKind state, JobFilter? filter, int from, int count)
+    {
+        var matches = new List<JobMatch>(count);
+        var scanned = 0;
+        var stateCount = StateCount(state);
+        var taken = 0;
+        var cursor = from;
+
+        while (taken < count && cursor < stateCount)
+        {
+            var remaining = (int)Math.Min(PageSize, stateCount - cursor);
+            var page = FetchPage(state, cursor, remaining);
+            if (page.Count == 0)
+            {
+                break;
+            }
+
+            foreach (var entry in page)
+            {
+                scanned++;
+                if (filter is null || JobFilterMatcher.Matches(entry, filter))
+                {
+                    matches.Add(entry);
+                    taken++;
+                    if (taken >= count)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            cursor += page.Count;
+        }
+
+        var truncated = taken >= count && cursor < stateCount;
+        return new ScanResult(matches, scanned, stateCount, truncated, cursor);
+    }
+
+    public ScanResult ScanByFilter(JobFilter filter, int max)
+    {
+        ArgumentNullException.ThrowIfNull(filter);
+        return ListJobs(filter.State, filter, 0, max);
+    }
+
+    private long StateCount(JobStateKind state) =>
+        state switch
+        {
+            JobStateKind.Enqueued => Api.Queues().Sum(q => Api.EnqueuedCount(q.Name)),
+            JobStateKind.Processing => Api.ProcessingCount(),
+            JobStateKind.Scheduled => Api.ScheduledCount(),
+            JobStateKind.Failed => Api.FailedCount(),
+            JobStateKind.Succeeded => Api.SucceededListCount(),
+            JobStateKind.Deleted => Api.DeletedListCount(),
+            _ => 0,
+        };
+
+    private IReadOnlyList<JobMatch> FetchPage(JobStateKind state, int from, int count) =>
+        state switch
+        {
+            JobStateKind.Enqueued => FetchEnqueued(from, count),
+            JobStateKind.Processing => Project(
+                Api.ProcessingJobs(from, count),
+                d => d.Job,
+                _ => null,
+                _ => null,
+                _ => null
+            ),
+            JobStateKind.Scheduled => Project(
+                Api.ScheduledJobs(from, count),
+                d => d.Job,
+                _ => null,
+                _ => null,
+                _ => null
+            ),
+            JobStateKind.Failed => Project(
+                Api.FailedJobs(from, count),
+                d => d.Job,
+                d => d.Reason,
+                d => d.ExceptionType,
+                d => d.ExceptionMessage
+            ),
+            JobStateKind.Succeeded => Project(
+                Api.SucceededJobs(from, count),
+                d => d.Job,
+                _ => null,
+                _ => null,
+                _ => null
+            ),
+            JobStateKind.Deleted => Project(
+                Api.DeletedJobs(from, count),
+                d => d.Job,
+                _ => null,
+                _ => null,
+                _ => null
+            ),
+            _ => Array.Empty<JobMatch>(),
+        };
+
+    private IReadOnlyList<JobMatch> FetchEnqueued(int from, int count)
+    {
+        var results = new List<JobMatch>();
+        var skip = from;
+        var take = count;
+        foreach (var queue in Api.Queues())
+        {
+            if (take <= 0)
+            {
+                break;
+            }
+            var len = (int)Api.EnqueuedCount(queue.Name);
+            if (skip >= len)
+            {
+                skip -= len;
+                continue;
+            }
+            var pageCount = Math.Min(take, len - skip);
+            foreach (var kvp in Api.EnqueuedJobs(queue.Name, skip, pageCount))
+            {
+                results.Add(new JobMatch(kvp.Key, kvp.Value.Job, queue.Name, null, null, null));
+            }
+            take -= pageCount;
+            skip = 0;
+        }
+        return results;
+    }
+
+    private static IReadOnlyList<JobMatch> Project<T>(
+        JobList<T> list,
+        Func<T, Job?> getJob,
+        Func<T, string?> getReason,
+        Func<T, string?> getExceptionType,
+        Func<T, string?> getExceptionMessage
+    )
+    {
+        var results = new List<JobMatch>(list.Count);
+        foreach (var kvp in list)
+        {
+            var dto = kvp.Value;
+            results.Add(
+                new JobMatch(
+                    kvp.Key,
+                    getJob(dto),
+                    getJob(dto)?.Queue,
+                    getReason(dto),
+                    getExceptionType(dto),
+                    getExceptionMessage(dto)
+                )
+            );
+        }
+        return results;
+    }
+}
+
+public sealed record JobMatch(
+    string Id,
+    Job? Job,
+    string? Queue,
+    string? Reason,
+    string? ExceptionType,
+    string? ExceptionMessage
+);
+
+public sealed record ScanResult(
+    IReadOnlyList<JobMatch> Matches,
+    int Scanned,
+    long StateTotal,
+    bool Truncated,
+    int NextFrom
+);

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using ModelContextProtocol.Protocol;
+
+namespace Nall.Hangfire.Mcp.Maintenance;
+
+public static class MaintenanceTools
+{
+    public const string Prefix = "hangfire_";
+
+    public const string GetStatistics = "hangfire_get_statistics";
+    public const string ListQueues = "hangfire_list_queues";
+    public const string ListJobs = "hangfire_list_jobs";
+    public const string GetJob = "hangfire_get_job";
+    public const string DeleteJob = "hangfire_delete_job";
+    public const string RequeueJob = "hangfire_requeue_job";
+    public const string DeleteJobs = "hangfire_delete_jobs";
+    public const string RequeueJobs = "hangfire_requeue_jobs";
+
+    public static IReadOnlyList<Tool> All { get; } = Build();
+
+    public static bool IsMaintenance(string? toolName) =>
+        toolName is not null && toolName.StartsWith(Prefix, StringComparison.Ordinal);
+
+    private static IReadOnlyList<Tool> Build() =>
+        new[]
+        {
+            new Tool
+            {
+                Name = GetStatistics,
+                Description =
+                    "Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.",
+                InputSchema = EmptyObject(),
+            },
+            new Tool
+            {
+                Name = ListQueues,
+                Description =
+                    "List Hangfire queues with their lengths and a sample of first enqueued jobs.",
+                InputSchema = EmptyObject(),
+            },
+            new Tool
+            {
+                Name = ListJobs,
+                Description =
+                    "Page Hangfire jobs by state with optional filter. Use this to discover ids before bulk delete/requeue.",
+                InputSchema = ListJobsSchema(),
+            },
+            new Tool
+            {
+                Name = GetJob,
+                Description =
+                    "Return full details for a single Hangfire job: type, method, args, properties, and state history.",
+                InputSchema = JobIdSchema(),
+            },
+            new Tool
+            {
+                Name = DeleteJob,
+                Description = "Move a single job to the Deleted state.",
+                InputSchema = JobIdSchema(),
+            },
+            new Tool
+            {
+                Name = RequeueJob,
+                Description =
+                    "Requeue a single job back to Enqueued (covers retry of Failed jobs).",
+                InputSchema = JobIdSchema(),
+            },
+            new Tool
+            {
+                Name = DeleteJobs,
+                Description =
+                    "Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.",
+                InputSchema = BulkSchema(),
+            },
+            new Tool
+            {
+                Name = RequeueJobs,
+                Description =
+                    "Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.",
+                InputSchema = BulkSchema(),
+            },
+        };
+
+    private static JsonElement EmptyObject() =>
+        ToElement(new JsonObject { ["type"] = "object", ["properties"] = new JsonObject() });
+
+    private static JsonElement JobIdSchema() =>
+        ToElement(
+            new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["id"] = new JsonObject
+                    {
+                        ["type"] = "string",
+                        ["description"] = "Hangfire job id.",
+                    },
+                },
+                ["required"] = new JsonArray { "id" },
+            }
+        );
+
+    private static JsonElement ListJobsSchema() =>
+        ToElement(
+            new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["state"] = StateEnum(),
+                    ["filter"] = FilterSchema(includeState: false),
+                    ["from"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["minimum"] = 0,
+                        ["default"] = 0,
+                    },
+                    ["count"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["minimum"] = 1,
+                        ["maximum"] = 100,
+                        ["default"] = 50,
+                    },
+                },
+                ["required"] = new JsonArray { "state" },
+            }
+        );
+
+    private static JsonElement BulkSchema() =>
+        ToElement(
+            new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["ids"] = new JsonObject
+                    {
+                        ["type"] = "array",
+                        ["items"] = new JsonObject { ["type"] = "string" },
+                        ["description"] = "Explicit job ids. Mutually exclusive with 'filter'.",
+                    },
+                    ["filter"] = FilterSchema(includeState: true),
+                    ["dryRun"] = new JsonObject
+                    {
+                        ["type"] = "boolean",
+                        ["default"] = false,
+                        ["description"] =
+                            "Recommended: set true first to preview matched ids without acting.",
+                    },
+                },
+            }
+        );
+
+    private static JsonObject FilterSchema(bool includeState)
+    {
+        var props = new JsonObject
+        {
+            ["queue"] = new JsonObject { ["type"] = "string" },
+            ["jobType"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Case-insensitive substring of Job.Type.FullName.",
+            },
+            ["method"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] = "Case-insensitive substring of Job.Method.Name.",
+            },
+            ["messageContains"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] =
+                    "Substring match against state Reason / failure message (most useful for Failed).",
+            },
+            ["exceptionContains"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["description"] =
+                    "Substring match against ExceptionType / ExceptionMessage (Failed only).",
+            },
+        };
+        var schema = new JsonObject { ["type"] = "object", ["properties"] = props };
+        if (includeState)
+        {
+            props["state"] = StateEnum();
+            schema["required"] = new JsonArray { "state" };
+        }
+        return schema;
+    }
+
+    private static JsonObject StateEnum() =>
+        new()
+        {
+            ["type"] = "string",
+            ["enum"] = new JsonArray(
+                "Enqueued",
+                "Processing",
+                "Scheduled",
+                "Failed",
+                "Succeeded",
+                "Deleted"
+            ),
+        };
+
+    private static JsonElement ToElement(JsonNode node) => JsonSerializer.SerializeToElement(node);
+}

--- a/src/Nall.Hangfire.Mcp/Manifest/JobManifestRegistry.cs
+++ b/src/Nall.Hangfire.Mcp/Manifest/JobManifestRegistry.cs
@@ -5,7 +5,7 @@ namespace Nall.Hangfire.Mcp.Manifest;
 
 public static class JobManifestRegistry
 {
-    private static readonly ConcurrentDictionary<Assembly, IReadOnlyList<JobDescriptor>> Sources =
+    private static readonly ConcurrentDictionary<Assembly, IReadOnlyList<JobDescriptor>> s_sources =
         new();
 
     public static void Add(
@@ -38,11 +38,11 @@ public static class JobManifestRegistry
             resolved.Add(JobDescriptor.FromManifest(type, info));
         }
 
-        Sources[source] = resolved;
+        s_sources[source] = resolved;
     }
 
     public static IReadOnlyList<JobDescriptor> AllDescriptors =>
-        Sources.Values.SelectMany(v => v).ToList();
+        s_sources.Values.SelectMany(v => v).ToList();
 
-    internal static void Clear() => Sources.Clear();
+    internal static void Clear() => s_sources.Clear();
 }

--- a/tests/Nall.Hangfire.Mcp.Tests/HangfireMcpHandlersTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/HangfireMcpHandlersTests.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using Hangfire;
 using Hangfire.InMemory;
 using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Maintenance;
 using Nall.Hangfire.Mcp.Tests.Fixtures;
 using Shouldly;
 
@@ -9,9 +10,11 @@ namespace Nall.Hangfire.Mcp.Tests;
 
 public class HangfireMcpHandlersTests
 {
-    private static (JobCatalog catalog, HangfireDynamicScheduler scheduler) Setup(
-        Action<IRecurringJobManager> register
-    )
+    private static (
+        JobCatalog catalog,
+        HangfireDynamicScheduler scheduler,
+        MaintenanceDispatcher maintenance
+    ) Setup(Action<IRecurringJobManager> register)
     {
         var storage = new InMemoryStorage();
         JobStorage.Current = storage;
@@ -19,7 +22,13 @@ public class HangfireMcpHandlersTests
         register(manager);
         var catalog = new JobCatalog(storage);
         var client = new BackgroundJobClient(storage);
-        return (catalog, new HangfireDynamicScheduler(client));
+        var query = new MaintenanceQueryService(storage);
+        var commands = new MaintenanceCommandService(client, query, 100);
+        return (
+            catalog,
+            new HangfireDynamicScheduler(client),
+            new MaintenanceDispatcher(query, commands)
+        );
     }
 
     private static IDictionary<string, JsonElement> ParseArgs(string json) =>
@@ -28,7 +37,7 @@ public class HangfireMcpHandlersTests
     [Fact]
     public void BuildListToolsResult_emits_one_tool_per_job_with_schema()
     {
-        var (catalog, _) = Setup(m =>
+        var (catalog, _, _) = Setup(m =>
         {
             m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily());
             m.AddOrUpdate<IEmailJob>("send-welcome", j => j.SendAsync("a"), Cron.Daily());
@@ -36,9 +45,10 @@ public class HangfireMcpHandlersTests
 
         var result = HangfireMcpHandlers.BuildListToolsResult(catalog);
 
-        result
-            .Tools.Select(t => t.Name)
-            .ShouldBe(["Run_nightly", "Run_send-welcome"], ignoreOrder: true);
+        var names = result.Tools.Select(t => t.Name).ToArray();
+        names.ShouldContain("Run_nightly");
+        names.ShouldContain("Run_send-welcome");
+        names.ShouldContain("hangfire_get_statistics");
         var nightly = result.Tools.Single(t => t.Name == "Run_nightly");
         var schema = JsonDocument.Parse(nightly.InputSchema.GetRawText()).RootElement;
         schema.GetProperty("type").GetString().ShouldBe("object");
@@ -48,13 +58,14 @@ public class HangfireMcpHandlersTests
     [Fact]
     public void InvokeTool_enqueues_and_returns_job_id()
     {
-        var (catalog, scheduler) = Setup(m =>
+        var (catalog, scheduler, maintenance) = Setup(m =>
             m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily())
         );
 
         var result = HangfireMcpHandlers.InvokeTool(
             catalog,
             scheduler,
+            maintenance,
             new CallToolRequestParams
             {
                 Name = "Run_nightly",
@@ -72,13 +83,14 @@ public class HangfireMcpHandlersTests
     [Fact]
     public void InvokeTool_returns_error_for_unknown_tool()
     {
-        var (catalog, scheduler) = Setup(m =>
+        var (catalog, scheduler, maintenance) = Setup(m =>
             m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily())
         );
 
         var result = HangfireMcpHandlers.InvokeTool(
             catalog,
             scheduler,
+            maintenance,
             new CallToolRequestParams { Name = "Run_does_not_exist" }
         );
 
@@ -92,13 +104,14 @@ public class HangfireMcpHandlersTests
     [Fact]
     public void InvokeTool_returns_error_when_required_argument_missing()
     {
-        var (catalog, scheduler) = Setup(m =>
+        var (catalog, scheduler, maintenance) = Setup(m =>
             m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily())
         );
 
         var result = HangfireMcpHandlers.InvokeTool(
             catalog,
             scheduler,
+            maintenance,
             new CallToolRequestParams
             {
                 Name = "Run_nightly",
@@ -116,13 +129,14 @@ public class HangfireMcpHandlersTests
     [Fact]
     public void InvokeTool_uses_default_argument_when_omitted()
     {
-        var (catalog, scheduler) = Setup(m =>
+        var (catalog, scheduler, maintenance) = Setup(m =>
             m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily())
         );
 
         var result = HangfireMcpHandlers.InvokeTool(
             catalog,
             scheduler,
+            maintenance,
             new CallToolRequestParams
             {
                 Name = "Run_nightly",

--- a/tests/Nall.Hangfire.Mcp.Tests/Maintenance/JobFilterMatcherTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Maintenance/JobFilterMatcherTests.cs
@@ -1,0 +1,121 @@
+using Nall.Hangfire.Mcp.Maintenance;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+using Job = Hangfire.Common.Job;
+
+namespace Nall.Hangfire.Mcp.Tests.Maintenance;
+
+public class JobFilterMatcherTests
+{
+    private static JobMatch Make(
+        Job? job,
+        string? queue = null,
+        string? reason = null,
+        string? exType = null,
+        string? exMsg = null
+    ) => new("id-1", job, queue, reason, exType, exMsg);
+
+    private static Job ReportJobInstance() =>
+        new(
+            typeof(ReportJob),
+            typeof(ReportJob).GetMethod(nameof(ReportJob.GenerateAsync))!,
+            2026,
+            "pdf"
+        );
+
+    [Fact]
+    public void Matches_returns_true_when_filter_is_empty_aside_from_state()
+    {
+        var match = Make(ReportJobInstance());
+        var filter = new JobFilter { State = JobStateKind.Failed };
+        JobFilterMatcher.Matches(match, filter).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void Queue_filter_is_case_insensitive_and_exact()
+    {
+        var match = Make(ReportJobInstance(), queue: "critical");
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Enqueued, Queue = "CRITICAL" })
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Enqueued, Queue = "default" })
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void JobType_and_Method_are_case_insensitive_substring()
+    {
+        var match = Make(ReportJobInstance());
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, JobType = "reportjob" })
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, Method = "GENERATE" })
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, JobType = "EmailJob" })
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Null_job_fails_jobtype_or_method_filters()
+    {
+        var match = Make(job: null);
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, JobType = "anything" })
+            .ShouldBeFalse();
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, Method = "anything" })
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void MessageContains_matches_reason_or_exception_message()
+    {
+        var match = Make(ReportJobInstance(), reason: "Connection timeout", exMsg: "SQL deadlock");
+        JobFilterMatcher
+            .Matches(
+                match,
+                new JobFilter { State = JobStateKind.Failed, MessageContains = "TIMEOUT" }
+            )
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(
+                match,
+                new JobFilter { State = JobStateKind.Failed, MessageContains = "deadlock" }
+            )
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(match, new JobFilter { State = JobStateKind.Failed, MessageContains = "404" })
+            .ShouldBeFalse();
+    }
+
+    [Fact]
+    public void ExceptionContains_matches_type_or_message()
+    {
+        var match = Make(
+            ReportJobInstance(),
+            exType: "System.Data.SqlClient.SqlException",
+            exMsg: "deadlock victim"
+        );
+        JobFilterMatcher
+            .Matches(
+                match,
+                new JobFilter { State = JobStateKind.Failed, ExceptionContains = "SqlException" }
+            )
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(
+                match,
+                new JobFilter { State = JobStateKind.Failed, ExceptionContains = "victim" }
+            )
+            .ShouldBeTrue();
+        JobFilterMatcher
+            .Matches(
+                match,
+                new JobFilter { State = JobStateKind.Failed, ExceptionContains = "Timeout" }
+            )
+            .ShouldBeFalse();
+    }
+}

--- a/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceCommandServiceTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceCommandServiceTests.cs
@@ -1,0 +1,107 @@
+using Hangfire;
+using Hangfire.InMemory;
+using Hangfire.States;
+using Nall.Hangfire.Mcp.Maintenance;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+
+namespace Nall.Hangfire.Mcp.Tests.Maintenance;
+
+public class MaintenanceCommandServiceTests
+{
+    private static (
+        BackgroundJobClient client,
+        MaintenanceQueryService query,
+        MaintenanceCommandService cmd,
+        JobStorage storage
+    ) Setup(int max = 100)
+    {
+        var storage = new InMemoryStorage();
+        JobStorage.Current = storage;
+        var client = new BackgroundJobClient(storage);
+        var query = new MaintenanceQueryService(storage);
+        var cmd = new MaintenanceCommandService(client, query, max);
+        return (client, query, cmd, storage);
+    }
+
+    [Fact]
+    public void DeleteOne_marks_job_deleted()
+    {
+        var (client, query, cmd, _) = Setup();
+        var id = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+
+        var result = cmd.DeleteOne(id);
+
+        result.Ok.ShouldBeTrue();
+        var details = query.GetJob(id);
+        details!.History[0].StateName.ShouldBe(DeletedState.StateName);
+    }
+
+    [Fact]
+    public void DeleteMany_with_ids_returns_per_id_results()
+    {
+        var (client, _, cmd, _) = Setup();
+        var ids = Enumerable
+            .Range(0, 3)
+            .Select(_ => client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf")))
+            .ToArray();
+
+        var result = cmd.DeleteMany(ids, filter: null, dryRun: false);
+
+        result.DryRun.ShouldBeFalse();
+        result.Results.Count.ShouldBe(3);
+        result.Results.ShouldAllBe(r => r.Ok);
+    }
+
+    [Fact]
+    public void DeleteMany_dryRun_returns_targets_without_acting()
+    {
+        var (client, query, cmd, _) = Setup();
+        var id = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+
+        var result = cmd.DeleteMany(new[] { id }, filter: null, dryRun: true);
+
+        result.DryRun.ShouldBeTrue();
+        result.Results.Single().Id.ShouldBe(id);
+        var details = query.GetJob(id);
+        details!.History[0].StateName.ShouldNotBe(DeletedState.StateName);
+    }
+
+    [Fact]
+    public void Bulk_requires_exactly_one_of_ids_or_filter()
+    {
+        var (_, _, cmd, _) = Setup();
+
+        Should.Throw<ArgumentException>(() => cmd.DeleteMany(null, null, false));
+        Should.Throw<ArgumentException>(() =>
+            cmd.DeleteMany(new[] { "a" }, new JobFilter { State = JobStateKind.Failed }, false)
+        );
+    }
+
+    [Fact]
+    public void Bulk_ids_count_above_cap_throws()
+    {
+        var (_, _, cmd, _) = Setup(max: 2);
+        Should.Throw<ArgumentException>(() => cmd.DeleteMany(new[] { "a", "b", "c" }, null, false));
+    }
+
+    [Fact]
+    public void DeleteMany_by_filter_targets_matching_jobs_only()
+    {
+        var (client, _, cmd, _) = Setup();
+        var keep = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+        var hit1 = client.Enqueue<MaintJob>(j => j.RunAsync());
+        var hit2 = client.Enqueue<MaintJob>(j => j.RunAsync());
+
+        var filter = new JobFilter { State = JobStateKind.Enqueued, JobType = "MaintJob" };
+        var result = cmd.DeleteMany(null, filter, dryRun: false);
+
+        result.Results.Select(r => r.Id).ShouldBe(new[] { hit1, hit2 }, ignoreOrder: true);
+        result.Results.ShouldAllBe(r => r.Ok);
+    }
+}
+
+public class MaintJob
+{
+    public Task RunAsync() => Task.CompletedTask;
+}

--- a/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceDispatcherTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceDispatcherTests.cs
@@ -1,0 +1,126 @@
+using System.Text.Json;
+using Hangfire;
+using Hangfire.InMemory;
+using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Maintenance;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+
+namespace Nall.Hangfire.Mcp.Tests.Maintenance;
+
+public class MaintenanceDispatcherTests
+{
+    private static (BackgroundJobClient client, MaintenanceDispatcher dispatcher) Setup()
+    {
+        var storage = new InMemoryStorage();
+        JobStorage.Current = storage;
+        var client = new BackgroundJobClient(storage);
+        var query = new MaintenanceQueryService(storage);
+        var commands = new MaintenanceCommandService(client, query, 100);
+        return (client, new MaintenanceDispatcher(query, commands));
+    }
+
+    private static IDictionary<string, JsonElement> Args(string json) =>
+        JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(json)!;
+
+    private static JsonElement ResultJson(CallToolResult r) =>
+        JsonDocument.Parse(((TextContentBlock)r.Content.Single()).Text!).RootElement.Clone();
+
+    [Fact]
+    public void GetStatistics_returns_counters()
+    {
+        var (_, d) = Setup();
+        var r = d.Invoke(new CallToolRequestParams { Name = MaintenanceTools.GetStatistics });
+        r.IsError.ShouldNotBe(true);
+        ResultJson(r).TryGetProperty("enqueued", out _).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void ListJobs_with_filter_finds_matching_enqueued()
+    {
+        var (client, d) = Setup();
+        var id = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+
+        var r = d.Invoke(
+            new CallToolRequestParams
+            {
+                Name = MaintenanceTools.ListJobs,
+                Arguments = Args("""{"state": "Enqueued", "filter": {"jobType": "ReportJob"}}"""),
+            }
+        );
+
+        r.IsError.ShouldNotBe(true);
+        var jobs = ResultJson(r).GetProperty("jobs");
+        jobs.GetArrayLength().ShouldBe(1);
+        jobs[0].GetProperty("id").GetString().ShouldBe(id);
+    }
+
+    [Fact]
+    public void DeleteJob_succeeds_and_GetJob_shows_deleted_state()
+    {
+        var (client, d) = Setup();
+        var id = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+
+        var del = d.Invoke(
+            new CallToolRequestParams
+            {
+                Name = MaintenanceTools.DeleteJob,
+                Arguments = Args($$"""{"id": "{{id}}"}"""),
+            }
+        );
+        del.IsError.ShouldNotBe(true);
+
+        var get = d.Invoke(
+            new CallToolRequestParams
+            {
+                Name = MaintenanceTools.GetJob,
+                Arguments = Args($$"""{"id": "{{id}}"}"""),
+            }
+        );
+        get.IsError.ShouldNotBe(true);
+        var json = ResultJson(get);
+        json.GetProperty("history")[0].GetProperty("stateName").GetString().ShouldBe("Deleted");
+    }
+
+    [Fact]
+    public void DeleteJobs_dryRun_returns_targets_without_acting()
+    {
+        var (client, d) = Setup();
+        var id = client.Enqueue<ReportJob>(j => j.GenerateAsync(2026, "pdf"));
+
+        var r = d.Invoke(
+            new CallToolRequestParams
+            {
+                Name = MaintenanceTools.DeleteJobs,
+                Arguments = Args($$"""{"ids": ["{{id}}"], "dryRun": true}"""),
+            }
+        );
+
+        r.IsError.ShouldNotBe(true);
+        var json = ResultJson(r);
+        json.GetProperty("dryRun").GetBoolean().ShouldBeTrue();
+        json.GetProperty("results")[0].GetProperty("id").GetString().ShouldBe(id);
+    }
+
+    [Fact]
+    public void DeleteJobs_rejects_both_ids_and_filter()
+    {
+        var (_, d) = Setup();
+        var r = d.Invoke(
+            new CallToolRequestParams
+            {
+                Name = MaintenanceTools.DeleteJobs,
+                Arguments = Args("""{"ids": ["x"], "filter": {"state": "Failed"}}"""),
+            }
+        );
+        r.IsError.ShouldBe(true);
+    }
+
+    [Fact]
+    public void Unknown_maintenance_tool_returns_error()
+    {
+        var (_, d) = Setup();
+        var r = d.Invoke(new CallToolRequestParams { Name = "hangfire_does_not_exist" });
+        r.IsError.ShouldBe(true);
+    }
+}


### PR DESCRIPTION
Closes #2.

## Summary
- Eight always-registered `hangfire_*` MCP tools alongside the dynamic `Run_<jobId>` tools — no extra wiring beyond `AddHangfireMcp()`.
- Read: `get_statistics`, `list_queues`, `list_jobs`, `get_job`.
- Write: `delete_job` / `requeue_job` (single), `delete_jobs` / `requeue_jobs` (bulk).
- Bulk tools accept either `ids[]` **or** `filter` (mutually exclusive). Filter supports `state`, `queue`, case-insensitive substring on `jobType` / `method`, and `messageContains` / `exceptionContains`.
- `dryRun: true` returns matched ids without acting — recommended in tool descriptions for any filter-based bulk call.
- Default bulk cap of 100 affected jobs per call, overridable via `HangfireMcpOptions.MaintenanceMaxBulkSize`.

## Implementation
- New `Maintenance/` namespace: `JobFilter`, `JobFilterMatcher`, `MaintenanceQueryService` (paged scan over `IMonitoringApi`), `MaintenanceCommandService` (single + bulk, per-id error capture), `MaintenanceTools` (definitions + JSON schemas), `MaintenanceDispatcher` (CallTool routing).
- `HangfireMcpHandlers` merges maintenance tools into `ListTools` and routes `hangfire_*` calls to the dispatcher; existing `Run_*` flow unchanged.
- README gains a "Built-in maintenance tools" section.

## Test plan
- [x] `dotnet test` — 52/52 passing (was 34, +18 new).
- [x] Unit: `JobFilterMatcherTests` (CI substring, queue match, message/exception, null-job).
- [x] Service: `MaintenanceCommandServiceTests` (delete/requeue single, dryRun, ids/filter exclusivity, cap).
- [x] Dispatch: `MaintenanceDispatcherTests` (statistics, list+filter, delete→get round-trip, dryRun, error paths) — exercises dispatcher → `IBackgroundJobClient` → `InMemoryStorage` end-to-end.