### PR TITLE
feat: OAuth/Keycloak auth sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,22 @@ For each tool call:
 - Nullable type (`T?` value or annotated reference) and no default → bound to `null` when omitted.
 - Otherwise required; missing argument returns an MCP error.
 
+## Authentication
+
+`MapHangfireMcp` returns `IEndpointConventionBuilder` — the library is auth-agnostic. Chain any ASP.NET Core auth scheme:
+
+```csharp
+app.MapHangfireMcp("/mcp")
+   .RequireAuthorization(p => p.RequireAuthenticatedUser()
+       .AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme));
+```
+
+- **OAuth 2.1 / OIDC** — `samples/Web` wires Keycloak + JwtBearer + `AddMcp()` from `ModelContextProtocol.AspNetCore.Authentication` to advertise RFC 9728 protected-resource-metadata. End-to-end flow, standards, and gotchas: [docs/auth.md](docs/auth.md).
+- **API keys / custom schemes** — nothing MCP-specific required. Implement an `AuthenticationHandler<T>`, register it, and pass its scheme to `RequireAuthorization` above. The `Run_*` and `hangfire_*` tools work the same regardless of how the principal got there.
+
 ## Sample
 
-`samples/Web` exercises overloads, complex objects, enums, collections, defaults, nullable optionals, and manifest-only one-shot jobs. `GET /jobs` lists the discovered catalog.
+[`samples/Web`](samples/Web/Program.cs) exercises overloads, complex objects, enums, collections, defaults, nullable optionals, and manifest-only one-shot jobs. `GET /jobs` lists the discovered catalog.
 
 ## License
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,166 @@
+# Authentication & Authorization
+
+The `Nall.Hangfire.Mcp` library is **auth-agnostic** — `MapHangfireMcp` returns an `IEndpointConventionBuilder`, so any ASP.NET Core auth scheme can be applied via `.RequireAuthorization(...)`. This document describes the `samples/Web` setup, the protocols involved, and where alternatives exist.
+
+## Standards in play
+
+| # | Spec | Role in this sample |
+|---|---|---|
+| 1 | [MCP Authorization (2025‑06‑18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization) | MCP server acts as an OAuth 2.1 **resource server**; auth is layered on, not built in |
+| 2 | [RFC 9728 — OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728) | `/.well-known/oauth-protected-resource/mcp` advertises which AS issues tokens for `/mcp` |
+| 3 | [RFC 6750 — Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750) | `Authorization: Bearer <jwt>` + `WWW-Authenticate` with `resource_metadata=` (RFC 9728 §5.1) |
+| 4 | [RFC 8414 — OAuth 2.0 Authorization Server Metadata](https://datatracker.ietf.org/doc/html/rfc8414) | Client discovers Keycloak's `authorization_endpoint`, `token_endpoint`, `jwks_uri`, `issuer` |
+| 5 | [RFC 7636 — PKCE](https://datatracker.ietf.org/doc/html/rfc7636) | Required for public clients (MCP Inspector, Swagger UI) |
+| 6 | [RFC 6749 — OAuth 2.0 Authorization Code](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) + [OIDC Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) | Token issuance flow |
+| 7 | [RFC 7519 — JWT](https://datatracker.ietf.org/doc/html/rfc7519) + [RFC 7517 — JWK](https://datatracker.ietf.org/doc/html/rfc7517) | Access token format + signing key distribution |
+| 8 | [WHATWG Fetch / W3C CORS](https://fetch.spec.whatwg.org/) | Browser preflight on the cross-origin metadata fetch |
+
+## End-to-end flow (MCP Inspector → `/mcp`)
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant C as MCP Inspector<br/>(browser, :6274)
+    participant R as Web / Resource Server<br/>(:5080)
+    participant AS as Keycloak / AS<br/>(:8080)
+
+    C->>R: POST /mcp (no token)
+    R-->>C: 401 + WWW-Authenticate: Bearer<br/>resource_metadata="…/oauth-protected-resource/mcp"
+    Note over C,R: RFC 6750 + RFC 9728 §5.1
+
+    C->>R: GET /.well-known/oauth-protected-resource/mcp
+    R-->>C: { resource, authorization_servers, scopes_supported }
+    Note over C,R: RFC 9728
+
+    C->>AS: GET /realms/X/.well-known/oauth-authorization-server
+    AS-->>C: { authorization_endpoint, token_endpoint, jwks_uri, issuer }
+    Note over C,AS: RFC 8414
+
+    C->>AS: GET authorization_endpoint?response_type=code&code_challenge=…
+    AS-->>C: 302 redirect_uri?code=…
+    Note over C,AS: RFC 6749 §4.1 + RFC 7636 (PKCE)
+
+    C->>AS: POST token_endpoint (code + code_verifier)
+    AS-->>C: { access_token: <JWT> }
+    Note over C,AS: RFC 6749 + OIDC Core 1.0
+
+    C->>R: POST /mcp Authorization: Bearer <JWT>
+    R->>AS: GET jwks_uri (cached)
+    AS-->>R: { keys: [...] }
+    Note over R,AS: RFC 7517 / RFC 7519
+    R-->>C: 200 (MCP JSON-RPC: initialize / tools/list / tools/call)
+```
+
+### Step-by-step
+
+**1. Unauthenticated `/mcp` request → RFC 9728-compliant challenge.**
+`MapHangfireMcp("/mcp").RequireAuthorization(... AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme))` routes the challenge through the `McpAuthenticationHandler` (from `ModelContextProtocol.AspNetCore.Authentication`). That handler emits `WWW-Authenticate: Bearer resource_metadata="…"` instead of a plain `Bearer` challenge — the `resource_metadata` parameter is the RFC 9728 extension that lets clients discover the AS without out-of-band config.
+
+> **Why a separate auth scheme?** The default JwtBearer challenge writes `WWW-Authenticate: Bearer error="…"` only — no `resource_metadata`. Clients that follow only RFC 6750 work; clients that follow MCP/RFC 9728 need the discovery pointer. We register both: JwtBearer **validates** tokens, McpAuthentication **challenges**. See `Program.cs:62‑72` and `Program.cs:241‑246`.
+
+**2. Protected-resource-metadata discovery.**
+`AddMcp(...)` registers an endpoint at `/.well-known/oauth-protected-resource/mcp` that returns:
+
+```json
+{
+  "resource": "http://localhost:5080/mcp",
+  "authorization_servers": ["http://localhost:8080/realms/HangfireMcp/"],
+  "scopes_supported": ["openid", "profile"]
+}
+```
+
+This is fetched **cross-origin** by the inspector's browser code (origin `http://localhost:6274` → `http://localhost:5080`), so a CORS policy is required (`Program.cs:78‑80`).
+
+**3. Authorization server metadata (RFC 8414).**
+The inspector hits `http://localhost:8080/realms/HangfireMcp/.well-known/oauth-authorization-server`. Keycloak 26.4+ exposes both this and the older `/.well-known/openid-configuration` (OIDC Discovery 1.0). RFC 8414 is the strictly OAuth-2.0-aligned one and is what MCP clients prefer.
+
+> **Keycloak version note.** RFC 8414 is only available in **Keycloak 26.4+**. `samples/AppHost/Program.cs` pins `WithImageTag("26.4")` for this reason.
+
+**4. Authorization Code + PKCE.**
+The inspector opens the `authorization_endpoint` URL with `response_type=code`, `code_challenge`, `code_challenge_method=S256`. The user authenticates against Keycloak (login form), Keycloak redirects back to the inspector's `redirect_uri` with `code=…`. PKCE is mandatory for public clients and is what the MCP spec recommends.
+
+**5. Token exchange.**
+The inspector POSTs `grant_type=authorization_code&code=…&code_verifier=…` to `token_endpoint` and receives a Keycloak access token (a signed JWT).
+
+**6. Authenticated `/mcp` call.**
+Subsequent MCP JSON-RPC calls carry `Authorization: Bearer <jwt>`. The default JwtBearer handler validates: signature (via JWKS), issuer, expiry, and audience (audience disabled here — see "Validation gotchas" below).
+
+## Server-side wiring (`samples/Web/Program.cs`)
+
+```csharp
+// 1. JwtBearer validates incoming JWTs.
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration,
+    o => {
+        o.RequireHttpsMetadata = false;
+        o.MetadataAddress = KeycloakConstants.OAuthAuthorizationServerMetadataPath; // RFC 8414 path
+    });
+
+// 2. McpAuthentication challenges with WWW-Authenticate: Bearer resource_metadata=...
+builder.Services.AddAuthentication()
+    .AddMcp(o => {
+        o.ResourceMetadata = new ProtectedResourceMetadata {
+            Resource = "http://localhost:5080/mcp",
+            AuthorizationServers = { keycloakOptions.KeycloakUrlRealm },
+            ScopesSupported = ["openid", "profile"],
+        };
+    });
+
+// 3. Browser CORS for cross-origin metadata fetch from the inspector.
+builder.Services.AddCors(o =>
+    o.AddDefaultPolicy(p => p.WithOrigins("http://localhost:6274").AllowAnyHeader()));
+
+// 4. Bind /mcp to the MCP challenge scheme so 401s carry resource_metadata.
+app.MapHangfireMcp("/mcp")
+   .RequireAuthorization(p =>
+       p.RequireAuthenticatedUser()
+        .AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme));
+```
+
+## Validation gotchas (this sample)
+
+### Issuer mismatch under Aspire service discovery
+
+`WithReference(keycloak)` injects a service-discovery URL (e.g. `http://_internal:.../`) into config. The default JwtBearer fetches metadata from that URL, caching its `issuer` and `jwks_uri`. But the JWT was minted via the browser-facing `http://localhost:8080`, so its `iss` claim doesn't match the cached metadata's `issuer` → `invalid_token: The issuer '…' is invalid`.
+
+Fix in `Program.cs:45‑60` — pin Authority/MetadataAddress/ValidIssuer to the public URL and null out the cached `ConfigurationManager`:
+
+```csharp
+var publicRealm = $"{keycloakOptions.AuthServerUrl.TrimEnd('/')}/realms/{keycloakOptions.Realm}/";
+builder.Services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+    .Configure(o => {
+        o.Authority = publicRealm;
+        o.MetadataAddress = publicRealm + KeycloakConstants.OAuthAuthorizationServerMetadataPath;
+        o.TokenValidationParameters.ValidIssuer = publicRealm.TrimEnd('/');
+        o.ConfigurationManager = null; // force rebuild with the new MetadataAddress
+    });
+```
+
+### Audience validation
+Keycloak access tokens carry `aud=account` by default. The sample disables audience checking (`verify-token-audience: false` in `appsettings.json`). Production-grade alternative: define an `audience` mapper on the `hangfire-mcp` client and set `Keycloak:Audience` accordingly.
+
+### Authorization-code flow is **not** Dynamic Client Registration (DCR)
+Keycloak supports DCR but the sample's realm policy rejects DCR-issued clients (`Allowed Client Scopes`). The inspector falls back to its **manual** OAuth form with `client_id=hangfire-mcp` (the static client imported via `HangfireMcp-realm.json`). This is intentional — DCR is one of the alternatives below.
+
+## Alternatives
+
+| Concern | Sample uses | Alternatives |
+|---|---|---|
+| Authorization Server | Keycloak 26.4 | Auth0, Okta, Entra ID, Cognito, Authelia, Hydra, any OAuth 2.1 / OIDC AS |
+| Server‑side auth lib | `Keycloak.AuthServices.Authentication` 3.0 + `Microsoft.AspNetCore.Authentication.JwtBearer` | Plain `AddJwtBearer` (vendor‑neutral), `Microsoft.Identity.Web` (Entra), OpenIddict, Duende IdentityServer client SDK |
+| Resource‑metadata advertising | `AddMcp()` from `ModelContextProtocol.AspNetCore.Authentication` | Hand-write a `/.well-known/oauth-protected-resource/<path>` endpoint + a custom challenge that injects `resource_metadata=` |
+| AS metadata format | RFC 8414 (`oauth-authorization-server`) | OIDC Discovery (`openid-configuration`) — superset, available on older Keycloak |
+| Token format | JWT (RS256) | Reference (opaque) tokens + RFC 7662 token introspection — chattier, but supports instant revocation |
+| Client | MCP Inspector (browser) + Swagger UI (browser) | `claude` desktop, VS Code MCP extension, any MCP client implementing RFC 9728 + PKCE |
+| OAuth flow | Authorization Code + PKCE | Device Code (RFC 8628) for headless CLIs; Client Credentials for service‑to‑service (no user) |
+| Client registration | Static realm import | DCR (RFC 7591) — clients self-register at runtime; requires permissive realm policy |
+| Browser cross-origin | CORS allow‑list for `http://localhost:6274` | Run inspector and resource on the same origin (reverse proxy); use a non-browser client (no CORS) |
+| Endpoint binding | `RequireAuthorization(... AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme))` | Set MCP scheme as the default challenge globally; or write a custom forwarder |
+
+
+## References
+
+- MCP spec: <https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization>
+- Keycloak 26.4 release notes (RFC 8414): <https://www.keycloak.org/docs/latest/release_notes/index.html>
+- `Keycloak.AuthServices`: <https://github.com/NikiforovAll/keycloak-authorization-services-dotnet>
+- `ModelContextProtocol.AspNetCore.Authentication`: <https://github.com/modelcontextprotocol/csharp-sdk>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -63,12 +63,12 @@ After a few seconds all resources become healthy:
 
 ![Aspire dashboard resources](assets/aspire-dashboard-resources.png)
 
-| Resource | Role |
-|---|---|
-| `server` | ASP.NET host — runs Hangfire server and exposes `/mcp` |
-| `postgres-server` / `hangfire` | Hangfire PostgreSQL storage |
-| `inspector` | [MCP Inspector](https://github.com/modelcontextprotocol/inspector) pre-wired to `/mcp` |
-| `hangfire-mcp` | Aspire-managed MCP proxy sidecar |
+| Resource                       | Role                                                                                   |
+| ------------------------------ | -------------------------------------------------------------------------------------- |
+| `server`                       | ASP.NET host — runs Hangfire server and exposes `/mcp`                                 |
+| `postgres-server` / `hangfire` | Hangfire PostgreSQL storage                                                            |
+| `inspector`                    | [MCP Inspector](https://github.com/modelcontextprotocol/inspector) pre-wired to `/mcp` |
+| `hangfire-mcp`                 | Aspire-managed MCP proxy sidecar                                                       |
 
 ---
 
@@ -76,15 +76,15 @@ After a few seconds all resources become healthy:
 
 `samples/HangfireJobs` defines six job interfaces that cover the full range of supported parameter shapes:
 
-| Recurring ID | Interface | Method | Parameters |
-|---|---|---|---|
-| `time.execute` | `ITimeJob` | `ExecuteAsync()` | none |
-| `send-message.text` | `ISendMessageJob` | `ExecuteAsync(string text)` | one required string |
-| `send-message.envelope` | `ISendMessageJob` | `ExecuteAsync(Message message)` | one required complex object |
-| `report.generate` | `IReportJob` | `GenerateAsync(int year, string format = "pdf", DateTimeOffset? since = null)` | one required + two optional |
-| `data.export` | `IDataExportJob` | `ExportAsync(ExportFormat format, IReadOnlyList<string> tables)` | enum + string array |
-| `maint.rebuild-indexes` | `MaintenanceJob` | `RebuildIndexesAsync(string schema = "public")` | one optional with default |
-| `notify.dispatch` | `INotificationJob` | `NotifyAsync(string channel, string? message, int? priority)` | required + nullable optionals |
+| Recurring ID            | Interface          | Method                                                                         | Parameters                    |
+| ----------------------- | ------------------ | ------------------------------------------------------------------------------ | ----------------------------- |
+| `time.execute`          | `ITimeJob`         | `ExecuteAsync()`                                                               | none                          |
+| `send-message.text`     | `ISendMessageJob`  | `ExecuteAsync(string text)`                                                    | one required string           |
+| `send-message.envelope` | `ISendMessageJob`  | `ExecuteAsync(Message message)`                                                | one required complex object   |
+| `report.generate`       | `IReportJob`       | `GenerateAsync(int year, string format = "pdf", DateTimeOffset? since = null)` | one required + two optional   |
+| `data.export`           | `IDataExportJob`   | `ExportAsync(ExportFormat format, IReadOnlyList<string> tables)`               | enum + string array           |
+| `maint.rebuild-indexes` | `MaintenanceJob`   | `RebuildIndexesAsync(string schema = "public")`                                | one optional with default     |
+| `notify.dispatch`       | `INotificationJob` | `NotifyAsync(string channel, string? message, int? priority)`                  | required + nullable optionals |
 
 Plus three **manifest-only** tools (discovered from one-shot `Enqueue` calls by the source generator):
 
@@ -162,11 +162,11 @@ Click any job to inspect its arguments, state transitions, and timing:
 
 ## Discovery sources
 
-| Source | What it discovers | When to use |
-|---|---|---|
-| `RecurringStorage` (default) | Jobs registered with `AddOrUpdate` (read from storage at startup) | Most apps — zero config |
-| `StaticManifest` | Jobs scanned at compile time by the source generator | One-shot `Enqueue` / `Schedule` jobs, or offline manifest without running Hangfire storage |
-| `All` | Union, deduplicated by `(DeclaringType, MethodInfo)` | When you want both |
+| Source                       | What it discovers                                                 | When to use                                                                                |
+| ---------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `RecurringStorage` (default) | Jobs registered with `AddOrUpdate` (read from storage at startup) | Most apps — zero config                                                                    |
+| `StaticManifest`             | Jobs scanned at compile time by the source generator              | One-shot `Enqueue` / `Schedule` jobs, or offline manifest without running Hangfire storage |
+| `All`                        | Union, deduplicated by `(DeclaringType, MethodInfo)`              | When you want both                                                                         |
 
 ```csharp
 builder.Services.AddHangfireMcp(o => o.Sources = JobDiscoverySources.All);
@@ -176,16 +176,16 @@ builder.Services.AddHangfireMcp(o => o.Sources = JobDiscoverySources.All);
 
 ## Parameter schema rules
 
-| C# signature | JSON Schema |
-|---|---|
-| `string name` | required string |
-| `string format = "pdf"` | optional string (default applied server-side) |
-| `string? tag` | optional string (nullable reference) |
-| `int? priority` | optional integer (nullable value type) |
-| `ExportFormat format` | required string enum (`"Csv"`, `"Json"`, `"Parquet"`) |
-| `IReadOnlyList<string> tables` | required array of strings |
-| `Message message` | required object with inferred JSON Schema |
-| `DateTimeOffset? since` | optional string (ISO 8601) |
+| C# signature                   | JSON Schema                                           |
+| ------------------------------ | ----------------------------------------------------- |
+| `string name`                  | required string                                       |
+| `string format = "pdf"`        | optional string (default applied server-side)         |
+| `string? tag`                  | optional string (nullable reference)                  |
+| `int? priority`                | optional integer (nullable value type)                |
+| `ExportFormat format`          | required string enum (`"Csv"`, `"Json"`, `"Parquet"`) |
+| `IReadOnlyList<string> tables` | required array of strings                             |
+| `Message message`              | required object with inferred JSON Schema             |
+| `DateTimeOffset? since`        | optional string (ISO 8601)                            |
 
 ---
 

--- a/samples/AppHost/AppHost.csproj
+++ b/samples/AppHost/AppHost.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.4" />
     <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.4" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.McpInspector" Version="13.1.1" />
+    <PackageReference Include="Keycloak.AuthServices.Aspire.Hosting" Version="0.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/AppHost/KeycloakConfiguration/HangfireMcp-realm.json
+++ b/samples/AppHost/KeycloakConfiguration/HangfireMcp-realm.json
@@ -1,0 +1,18 @@
+{
+  "realm": "HangfireMcp",
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": false,
+  "clients": [
+    {
+      "clientId": "hangfire-mcp",
+      "name": "Hangfire MCP",
+      "enabled": true,
+      "publicClient": true,
+      "directAccessGrantsEnabled": true,
+      "standardFlowEnabled": true,
+      "redirectUris": ["*"],
+      "webOrigins": ["*"]
+    }
+  ]
+}

--- a/samples/AppHost/KeycloakConfiguration/HangfireMcp-users-0.json
+++ b/samples/AppHost/KeycloakConfiguration/HangfireMcp-users-0.json
@@ -1,0 +1,21 @@
+{
+  "realm": "HangfireMcp",
+  "users": [
+    {
+      "username": "test",
+      "firstName": "Test",
+      "lastName": "User",
+      "email": "test@hangfire.local",
+      "emailVerified": true,
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test",
+          "temporary": false
+        }
+      ],
+      "realmRoles": ["default-roles-hangfiremcp"]
+    }
+  ]
+}

--- a/samples/AppHost/Program.cs
+++ b/samples/AppHost/Program.cs
@@ -21,17 +21,29 @@ var postgresDatabase = postgresServer
 postgresDatabase.WithPostgresMcp();
 #pragma warning restore ASPIREPOSTGRES001
 
+var keycloak = builder
+    .AddKeycloakContainer("keycloak")
+    .WithImageTag("26.4")
+    .WithImport("./KeycloakConfiguration/HangfireMcp-realm.json")
+    .WithImport("./KeycloakConfiguration/HangfireMcp-users-0.json");
+
+var realm = keycloak.AddRealm("HangfireMcp");
+
 #pragma warning disable ASPIREMCP001
 var web = builder
     .AddProject<Projects.Web>("server")
     .WithReference(postgresDatabase)
     .WaitFor(postgresDatabase)
+    .WithReference(keycloak)
+    .WithReference(realm)
+    .WaitFor(keycloak)
     .WithMcpServer("/mcp");
 #pragma warning restore ASPIREMCP001
 
 builder
     .AddMcpInspector("inspector", new McpInspectorOptions { InspectorVersion = "0.21.2" })
-    .WithMcpServer(web)
-    .WithEnvironment("DANGEROUSLY_OMIT_AUTH", "true");
+    .WithEnvironment("DANGEROUSLY_OMIT_AUTH", "true")
+    .WithEnvironment("NODE_OPTIONS", "--max-http-header-size=32768")
+    .WithMcpServer(web);
 
 builder.Build().Run();

--- a/samples/Web/Program.cs
+++ b/samples/Web/Program.cs
@@ -1,5 +1,11 @@
+using System.Security.Claims;
 using Hangfire;
 using HangfireJobs;
+using Keycloak.AuthServices.Authentication;
+using Keycloak.AuthServices.Common;
+using Microsoft.OpenApi.Models;
+using ModelContextProtocol.AspNetCore.Authentication;
+using ModelContextProtocol.Authentication;
 using Nall.Hangfire.Mcp;
 using Web;
 
@@ -18,9 +24,125 @@ builder.Services.AddProblemDetails();
 // the source generator. Default is RecurringStorage only.
 builder.Services.AddHangfireMcp(o => o.Sources = JobDiscoverySources.All);
 
+// Keycloak-backed JWT bearer auth + MCP protected-resource-metadata challenge.
+// The library itself is auth-agnostic — MapHangfireMcp returns IEndpointConventionBuilder,
+// so any ASP.NET Core auth scheme can be applied by chaining .RequireAuthorization() below.
+var keycloakOptions = builder.Configuration.GetKeycloakOptions<KeycloakAuthenticationOptions>()!;
+
+builder.Services.AddKeycloakWebApiAuthentication(
+    builder.Configuration,
+    options =>
+    {
+        options.RequireHttpsMetadata = false;
+        options.MetadataAddress = KeycloakConstants.OAuthAuthorizationServerMetadataPath;
+    }
+);
+
+// Aspire service discovery rewrites the Keycloak URL to a container-internal host,
+// so JWTs minted via the browser-facing localhost:8080 fail issuer validation
+// (token iss = http://localhost:8080/... vs metadata issuer = service-discovery host).
+// Pin Authority/MetadataAddress to the public URL so issuers match.
+{
+    var publicRealm =
+        $"{keycloakOptions.AuthServerUrl!.TrimEnd('/')}/realms/{keycloakOptions.Realm}/";
+    builder
+        .Services.AddOptions<Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerOptions>(
+            Microsoft.AspNetCore.Authentication.JwtBearer.JwtBearerDefaults.AuthenticationScheme
+        )
+        .Configure(o =>
+        {
+            o.Authority = publicRealm;
+            o.MetadataAddress =
+                publicRealm + KeycloakConstants.OAuthAuthorizationServerMetadataPath;
+            o.TokenValidationParameters.ValidIssuer = publicRealm.TrimEnd('/');
+            o.ConfigurationManager = null;
+        });
+}
+
+builder
+    .Services.AddAuthentication()
+    .AddMcp(options =>
+    {
+        options.ResourceMetadata = new ProtectedResourceMetadata
+        {
+            Resource = builder.Configuration["McpServerUrl"] ?? "http://localhost:5000/mcp",
+            AuthorizationServers = { keycloakOptions.KeycloakUrlRealm },
+            ScopesSupported = ["openid", "profile"],
+        };
+    });
+
+builder.Services.AddAuthorization();
+
+// MCP Inspector (browser) fetches /.well-known/oauth-protected-resource/mcp
+// cross-origin from http://localhost:6274 during OAuth discovery.
+builder.Services.AddCors(o =>
+    o.AddDefaultPolicy(p => p.WithOrigins("http://localhost:6274").AllowAnyHeader())
+);
+
+// Swagger UI wired to Keycloak — used to obtain a bearer token for testing /mcp.
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.AddSecurityDefinition(
+        "oauth2",
+        new OpenApiSecurityScheme
+        {
+            Type = SecuritySchemeType.OAuth2,
+            Flows = new OpenApiOAuthFlows
+            {
+                AuthorizationCode = new OpenApiOAuthFlow
+                {
+                    AuthorizationUrl = new Uri(
+                        $"{keycloakOptions.KeycloakUrlRealm}protocol/openid-connect/auth"
+                    ),
+                    TokenUrl = new Uri(
+                        $"{keycloakOptions.KeycloakUrlRealm}protocol/openid-connect/token"
+                    ),
+                    Scopes = new Dictionary<string, string>
+                    {
+                        ["openid"] = "OpenID",
+                        ["profile"] = "Profile",
+                    },
+                },
+            },
+        }
+    );
+    c.AddSecurityRequirement(
+        new OpenApiSecurityRequirement
+        {
+            {
+                new OpenApiSecurityScheme
+                {
+                    Reference = new OpenApiReference
+                    {
+                        Type = ReferenceType.SecurityScheme,
+                        Id = "oauth2",
+                    },
+                },
+                new[] { "openid", "profile" }
+            },
+        }
+    );
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Hangfire MCP Sample", Version = "v1" });
+});
+
 var app = builder.Build();
 app.UseHttpsRedirection();
-app.MapHangfireDashboard(string.Empty);
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.UseSwagger();
+app.UseSwaggerUI(o =>
+{
+    o.SwaggerEndpoint("/swagger/v1/swagger.json", "v1");
+    o.RoutePrefix = string.Empty;
+    o.OAuthClientId("hangfire-mcp");
+    o.OAuthUsePkce();
+    o.OAuthScopes("openid", "profile");
+});
+
+app.MapHangfireDashboard("/hangfire");
 
 var recurring = app.Services.GetRequiredService<IRecurringJobManager>();
 
@@ -78,27 +200,49 @@ client.Enqueue<MaintenanceJob>(j => j.VacuumAsync("orders", true));
 client.Enqueue<INotificationJob>(j => j.BroadcastAsync("startup", null, null));
 
 app.MapGet(
-    "/jobs",
-    (JobCatalog catalog) =>
-        Results.Ok(
-            catalog.Jobs.Select(d => new
-            {
-                d.RecurringJobId,
-                d.ToolName,
-                DeclaringType = d.DeclaringType.FullName,
-                Method = d.Method.Name,
-                Parameters = d
-                    .Method.GetParameters()
-                    .Select(p => new
-                    {
-                        p.Name,
-                        Type = p.ParameterType.FullName,
-                        HasDefault = p.HasDefaultValue,
-                    }),
-            })
-        )
-);
+        "/jobs",
+        (JobCatalog catalog) =>
+            Results.Ok(
+                catalog.Jobs.Select(d => new
+                {
+                    d.RecurringJobId,
+                    d.ToolName,
+                    DeclaringType = d.DeclaringType.FullName,
+                    Method = d.Method.Name,
+                    Parameters = d
+                        .Method.GetParameters()
+                        .Select(p => new
+                        {
+                            p.Name,
+                            Type = p.ParameterType.FullName,
+                            HasDefault = p.HasDefaultValue,
+                        }),
+                })
+            )
+    )
+    .RequireAuthorization();
 
-app.MapHangfireMcp("/mcp");
+// Echo the authenticated principal — quick way to verify a token works end-to-end
+// before exercising /mcp.
+app.MapGet(
+        "/auth-info",
+        (ClaimsPrincipal user) =>
+            Results.Ok(
+                new
+                {
+                    Name = user.Identity?.Name,
+                    IsAuthenticated = user.Identity?.IsAuthenticated ?? false,
+                    Claims = user.Claims.Select(c => new { c.Type, c.Value }),
+                }
+            )
+    )
+    .RequireAuthorization();
+
+app.MapHangfireMcp("/mcp")
+    .RequireAuthorization(policy =>
+        policy
+            .RequireAuthenticatedUser()
+            .AddAuthenticationSchemes(McpAuthenticationDefaults.AuthenticationScheme)
+    );
 
 app.Run();

--- a/samples/Web/Web.csproj
+++ b/samples/Web/Web.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Hangfire.AspNetCore" Version="1.8.23" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.21.1" />
+    <PackageReference Include="Keycloak.AuthServices.Authentication" Version="3.0.0-rc.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/Web/appsettings.Development.json
+++ b/samples/Web/appsettings.Development.json
@@ -5,5 +5,6 @@
       "Microsoft.AspNetCore": "Warning",
       "Hangfire": "Information"
     }
-  }
+  },
+  "McpServerUrl": "http://localhost:5080/mcp"
 }

--- a/samples/Web/appsettings.json
+++ b/samples/Web/appsettings.json
@@ -5,5 +5,12 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Keycloak": {
+    "realm": "HangfireMcp",
+    "auth-server-url": "http://localhost:8080/",
+    "ssl-required": "none",
+    "resource": "hangfire-mcp",
+    "verify-token-audience": false
+  }
 }


### PR DESCRIPTION
Closes #3.

## Summary
- `samples/Web` now demonstrates OAuth 2.1 / OIDC on `/mcp` end-to-end: Keycloak (via Aspire) + JwtBearer validation + `AddMcp()` for RFC 9728 protected-resource-metadata challenge.
- Pins JwtBearer Authority/MetadataAddress/ValidIssuer to the public realm URL so JWTs minted via `localhost:8080` validate despite Aspire service-discovery rewriting the Keycloak host.
- CORS allow-list for the MCP Inspector origin (`:6274`) so the cross-origin `.well-known` fetch during OAuth discovery succeeds.
- Swagger UI wired to Keycloak with PKCE for quick token acquisition.
- New `docs/auth.md`: standards table (MCP auth spec, RFC 9728/8414/6750/7636/6749/7517/7519), mermaid sequence diagram of the full Inspector → `/mcp` flow, server-side wiring excerpts, validation gotchas (Aspire issuer mismatch, audience), and alternatives matrix (other ASes, opaque tokens, DCR, device code, etc.).
- README: new Authentication section linking to the sample/doc and noting that hand-rolled API key auth is just a standard ASP.NET Core `AuthenticationHandler` — nothing MCP-specific.

The library itself remains auth-agnostic: `MapHangfireMcp` still returns `IEndpointConventionBuilder`, so any scheme composes via `.RequireAuthorization(...)`.

## Test plan
- [x] `aspire run` brings up Keycloak + Web + Inspector
- [x] Inspector OAuth flow completes; `/mcp` accepts bearer tokens
- [x] `GET /auth-info` returns 200 with claims for an authenticated principal
- [x] `/.well-known/oauth-protected-resource/mcp` returns metadata cross-origin
- [x] `WWW-Authenticate` on unauthenticated `/mcp` includes `resource_metadata=`