### PR TITLE
feat: MCP prompts for Hangfire admin/run discovery

### DIFF
--- a/src/Nall.Hangfire.Mcp/HangfireMcpHandlers.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpHandlers.cs
@@ -1,10 +1,27 @@
 using ModelContextProtocol.Protocol;
 using Nall.Hangfire.Mcp.Maintenance;
+using Nall.Hangfire.Mcp.Prompts;
 
 namespace Nall.Hangfire.Mcp;
 
 public static class HangfireMcpHandlers
 {
+    public static ListPromptsResult BuildListPromptsResult() =>
+        new() { Prompts = MaintenancePrompts.All.ToList() };
+
+    public static GetPromptResult GetPrompt(JobCatalog catalog, GetPromptRequestParams? @params)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        var name =
+            @params?.Name
+            ?? throw new ArgumentException("Prompt name is required.", nameof(@params));
+        if (!MaintenancePrompts.IsKnown(name))
+        {
+            throw new ArgumentException($"Unknown prompt '{name}'.", nameof(@params));
+        }
+        return MaintenancePrompts.Render(name, catalog);
+    }
+
     public static ListToolsResult BuildListToolsResult(JobCatalog catalog)
     {
         ArgumentNullException.ThrowIfNull(catalog);

--- a/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
+++ b/src/Nall.Hangfire.Mcp/HangfireMcpServiceCollectionExtensions.cs
@@ -62,6 +62,19 @@ public static class HangfireMcpServiceCollectionExtensions
                         )
                     );
                 }
+            )
+            .WithListPromptsHandler(
+                static (request, ct) =>
+                    ValueTask.FromResult(HangfireMcpHandlers.BuildListPromptsResult())
+            )
+            .WithGetPromptHandler(
+                static (request, ct) =>
+                {
+                    var catalog = request.Services!.GetRequiredService<JobCatalog>();
+                    return ValueTask.FromResult(
+                        HangfireMcpHandlers.GetPrompt(catalog, request.Params)
+                    );
+                }
             );
     }
 }

--- a/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
+++ b/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
@@ -1,0 +1,134 @@
+using System.Text;
+using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Maintenance;
+
+namespace Nall.Hangfire.Mcp.Prompts;
+
+public static class MaintenancePrompts
+{
+    public const string HealthCheck = "hangfire_health_check";
+    public const string TriageFailures = "hangfire_triage_failures";
+    public const string Discover = "hangfire_discover";
+
+    public static IReadOnlyList<Prompt> All { get; } = Build();
+
+    public static bool IsKnown(string? name) => name is HealthCheck or TriageFailures or Discover;
+
+    public static GetPromptResult Render(string name, JobCatalog catalog)
+    {
+        ArgumentNullException.ThrowIfNull(catalog);
+        return name switch
+        {
+            HealthCheck => RenderHealthCheck(),
+            TriageFailures => RenderTriageFailures(),
+            Discover => RenderDiscover(catalog),
+            _ => throw new ArgumentException($"Unknown prompt '{name}'.", nameof(name)),
+        };
+    }
+
+    private static IReadOnlyList<Prompt> Build() =>
+        [
+            new Prompt
+            {
+                Name = Discover,
+                Title = "Discover Hangfire MCP capabilities",
+                Description =
+                    "Mindmap of what this MCP server exposes: operational prompts and discovered Hangfire jobs that can be run.",
+            },
+            new Prompt
+            {
+                Name = HealthCheck,
+                Title = "Hangfire health check",
+                Description =
+                    "Summarize Hangfire backlog, failure rate and server/queue anomalies into a one-screen operational report.",
+            },
+            new Prompt
+            {
+                Name = TriageFailures,
+                Title = "Triage failed jobs",
+                Description =
+                    "Investigate failed jobs grouped by job type and exception, then recommend requeue vs delete (with dryRun-then-confirm safety pattern).",
+            },
+        ];
+
+    private static GetPromptResult RenderHealthCheck()
+    {
+        const string text = """
+            You are a Hangfire operations assistant. Produce a one-screen health report by following these steps:
+
+            1. Call tool `hangfire_get_statistics` to retrieve global counters.
+            2. Call tool `hangfire_list_queues` to inspect per-queue lengths.
+            3. Synthesize a structured report with these sections:
+               - **Backlog**: Enqueued + Scheduled totals; flag if any single queue length exceeds 1000.
+               - **Failures**: Failed count and Retries; flag if Failed > 50 or > 1% of Succeeded.
+               - **Throughput**: Processing count vs Servers; flag if Processing > 0 but Servers = 0.
+               - **Recurring**: Recurring count.
+               - **Verdict**: a single line — "Healthy", "Degraded", or "Unhealthy" — with the dominant reason.
+
+            Do not call any destructive tool (`hangfire_delete_*`, `hangfire_requeue_*`). This prompt is read-only.
+            """;
+        return TextUserPrompt("Hangfire operational health summary.", text);
+    }
+
+    private static GetPromptResult RenderTriageFailures()
+    {
+        const string text = """
+            You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend a remediation per failure group.
+
+            Steps:
+            1. Call `hangfire_list_jobs` with `state="Failed"`, `count=100`. Optionally narrow with `filter.jobType` if the user named a specific job.
+            2. Group results by `(jobType, exceptionType, first 80 chars of exceptionMessage)`. Sort by group size descending.
+            3. For each group, call `hangfire_get_job` on one representative id to fetch full state history.
+            4. Classify each group:
+               - **Transient** (timeout, network, 5xx, deadlock) → recommend **requeue**.
+               - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → recommend **delete**.
+               - **Unknown** → recommend manual investigation, do not act.
+            5. Present a markdown table: jobType | exception | count | recommendation | reasoning.
+            6. SAFETY: Before any destructive action, you MUST first call `hangfire_delete_jobs` or `hangfire_requeue_jobs` with `dryRun=true` and the same filter, show the matched ids to the user, and explicitly ask for confirmation. Only call again with `dryRun=false` after the user confirms.
+            """;
+        return TextUserPrompt("Triage Hangfire failure groups.", text);
+    }
+
+    private static GetPromptResult RenderDiscover(JobCatalog catalog)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Hangfire MCP capabilities (mindmap):");
+        sb.AppendLine();
+        sb.AppendLine("- Maintenance tools");
+        foreach (var tool in MaintenanceTools.All)
+        {
+            sb.AppendLine($"  - `{tool.Name}` — {tool.Description}");
+        }
+        sb.AppendLine("- Run jobs (tools)");
+        if (catalog.ListToolsResult.Tools.Count == 0)
+        {
+            sb.AppendLine("  - (no jobs discovered)");
+        }
+        else
+        {
+            foreach (var tool in catalog.ListToolsResult.Tools)
+            {
+                sb.AppendLine($"  - `{tool.Name}` — {tool.Description}");
+            }
+        }
+
+        return TextUserPrompt(
+            "Mindmap of Hangfire MCP prompts and discovered jobs.",
+            sb.ToString().TrimEnd()
+        );
+    }
+
+    private static GetPromptResult TextUserPrompt(string description, string text) =>
+        new()
+        {
+            Description = description,
+            Messages =
+            [
+                new PromptMessage
+                {
+                    Role = Role.User,
+                    Content = new TextContentBlock { Text = text },
+                },
+            ],
+        };
+}

--- a/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
+++ b/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
@@ -113,7 +113,7 @@ public static class MaintenancePrompts
         }
 
         return TextUserPrompt(
-            "Mindmap of Hangfire MCP prompts and discovered jobs.",
+            "Mindmap of Hangfire MCP maintenance and run-job tools.",
             sb.ToString().TrimEnd()
         );
     }

--- a/tests/Nall.Hangfire.Mcp.Tests/Nall.Hangfire.Mcp.Tests.csproj
+++ b/tests/Nall.Hangfire.Mcp.Tests/Nall.Hangfire.Mcp.Tests.csproj
@@ -9,8 +9,10 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="2.4.1" />
     <PackageReference Include="Hangfire.InMemory" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
+    <PackageReference Include="Verify.Xunit" Version="30.0.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
   </ItemGroup>

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
@@ -1,0 +1,15 @@
+﻿description: Mindmap of Hangfire MCP prompts and discovered jobs.
+---
+Hangfire MCP capabilities (mindmap):
+
+- Maintenance tools
+  - `hangfire_get_statistics` — Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.
+  - `hangfire_list_queues` — List Hangfire queues with their lengths and a sample of first enqueued jobs.
+  - `hangfire_list_jobs` — Page Hangfire jobs by state with optional filter. Use this to discover ids before bulk delete/requeue.
+  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
+  - `hangfire_delete_job` — Move a single job to the Deleted state.
+  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs).
+  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+- Run jobs (tools)
+  - (no jobs discovered)

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
@@ -1,4 +1,4 @@
-﻿description: Mindmap of Hangfire MCP prompts and discovered jobs.
+﻿description: Mindmap of Hangfire MCP maintenance and run-job tools.
 ---
 Hangfire MCP capabilities (mindmap):
 

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -1,0 +1,16 @@
+﻿description: Mindmap of Hangfire MCP prompts and discovered jobs.
+---
+Hangfire MCP capabilities (mindmap):
+
+- Maintenance tools
+  - `hangfire_get_statistics` — Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.
+  - `hangfire_list_queues` — List Hangfire queues with their lengths and a sample of first enqueued jobs.
+  - `hangfire_list_jobs` — Page Hangfire jobs by state with optional filter. Use this to discover ids before bulk delete/requeue.
+  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
+  - `hangfire_delete_job` — Move a single job to the Deleted state.
+  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs).
+  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+- Run jobs (tools)
+  - `Run_nightly` — Enqueue Hangfire job 'nightly' (ReportJob.GenerateAsync).
+  - `Run_send-welcome` — Enqueue Hangfire job 'send-welcome' (IEmailJob.SendAsync).

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -1,4 +1,4 @@
-﻿description: Mindmap of Hangfire MCP prompts and discovered jobs.
+﻿description: Mindmap of Hangfire MCP maintenance and run-job tools.
 ---
 Hangfire MCP capabilities (mindmap):
 

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_health_check.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_health_check.verified.txt
@@ -1,0 +1,14 @@
+﻿description: Hangfire operational health summary.
+---
+You are a Hangfire operations assistant. Produce a one-screen health report by following these steps:
+
+1. Call tool `hangfire_get_statistics` to retrieve global counters.
+2. Call tool `hangfire_list_queues` to inspect per-queue lengths.
+3. Synthesize a structured report with these sections:
+   - **Backlog**: Enqueued + Scheduled totals; flag if any single queue length exceeds 1000.
+   - **Failures**: Failed count and Retries; flag if Failed > 50 or > 1% of Succeeded.
+   - **Throughput**: Processing count vs Servers; flag if Processing > 0 but Servers = 0.
+   - **Recurring**: Recurring count.
+   - **Verdict**: a single line — "Healthy", "Degraded", or "Unhealthy" — with the dominant reason.
+
+Do not call any destructive tool (`hangfire_delete_*`, `hangfire_requeue_*`). This prompt is read-only.

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_triage_failures.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_triage_failures.verified.txt
@@ -1,0 +1,14 @@
+﻿description: Triage Hangfire failure groups.
+---
+You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend a remediation per failure group.
+
+Steps:
+1. Call `hangfire_list_jobs` with `state="Failed"`, `count=100`. Optionally narrow with `filter.jobType` if the user named a specific job.
+2. Group results by `(jobType, exceptionType, first 80 chars of exceptionMessage)`. Sort by group size descending.
+3. For each group, call `hangfire_get_job` on one representative id to fetch full state history.
+4. Classify each group:
+   - **Transient** (timeout, network, 5xx, deadlock) → recommend **requeue**.
+   - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → recommend **delete**.
+   - **Unknown** → recommend manual investigation, do not act.
+5. Present a markdown table: jobType | exception | count | recommendation | reasoning.
+6. SAFETY: Before any destructive action, you MUST first call `hangfire_delete_jobs` or `hangfire_requeue_jobs` with `dryRun=true` and the same filter, show the matched ids to the user, and explicitly ask for confirmation. Only call again with `dryRun=false` after the user confirms.

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.cs
@@ -1,0 +1,80 @@
+using Hangfire;
+using Hangfire.InMemory;
+using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Prompts;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+
+namespace Nall.Hangfire.Mcp.Tests.Prompts;
+
+public class MaintenancePromptsTests
+{
+    private static JobCatalog Setup(Action<IRecurringJobManager> register)
+    {
+        var storage = new InMemoryStorage();
+        JobStorage.Current = storage;
+        register(new RecurringJobManager(storage));
+        return new JobCatalog(storage);
+    }
+
+    [Fact]
+    public void All_lists_three_prompts_with_expected_names()
+    {
+        MaintenancePrompts
+            .All.Select(p => p.Name)
+            .ShouldBe(
+                new[]
+                {
+                    MaintenancePrompts.Discover,
+                    MaintenancePrompts.HealthCheck,
+                    MaintenancePrompts.TriageFailures,
+                },
+                ignoreOrder: true
+            );
+    }
+
+    [Fact]
+    public Task Render_health_check() =>
+        Verify(ToText(MaintenancePrompts.Render(MaintenancePrompts.HealthCheck, EmptyCatalog())));
+
+    [Fact]
+    public Task Render_triage_failures() =>
+        Verify(
+            ToText(MaintenancePrompts.Render(MaintenancePrompts.TriageFailures, EmptyCatalog()))
+        );
+
+    [Fact]
+    public Task Render_discover_with_jobs()
+    {
+        var catalog = Setup(m =>
+        {
+            m.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily());
+            m.AddOrUpdate<IEmailJob>("send-welcome", j => j.SendAsync("a"), Cron.Daily());
+        });
+        return Verify(ToText(MaintenancePrompts.Render(MaintenancePrompts.Discover, catalog)));
+    }
+
+    [Fact]
+    public Task Render_discover_empty_catalog() =>
+        Verify(ToText(MaintenancePrompts.Render(MaintenancePrompts.Discover, EmptyCatalog())));
+
+    [Fact]
+    public void Render_throws_for_unknown_prompt()
+    {
+        Should
+            .Throw<ArgumentException>(() =>
+                MaintenancePrompts.Render("hangfire_does_not_exist", EmptyCatalog())
+            )
+            .Message.ShouldContain("Unknown prompt");
+    }
+
+    private static JobCatalog EmptyCatalog() => Setup(_ => { });
+
+    private static string ToText(GetPromptResult result)
+    {
+        var msg = result.Messages.ShouldHaveSingleItem();
+        msg.Role.ShouldBe(Role.User);
+        var text = msg.Content.ShouldBeOfType<TextContentBlock>().Text;
+        return $"description: {result.Description}\n---\n{text}";
+    }
+}

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/McpPromptsIntegrationTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/McpPromptsIntegrationTests.cs
@@ -1,0 +1,126 @@
+using Hangfire;
+using Hangfire.InMemory;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Prompts;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+
+namespace Nall.Hangfire.Mcp.Tests.Prompts;
+
+public class McpPromptsIntegrationTests : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private McpClient _client = null!;
+
+    public async Task InitializeAsync()
+    {
+        var storage = new InMemoryStorage();
+        JobStorage.Current = storage;
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddSingleton<JobStorage>(storage);
+                    services.AddSingleton<IBackgroundJobClient>(_ => new BackgroundJobClient(
+                        storage
+                    ));
+                    services.AddSingleton<IRecurringJobManager>(_ => new RecurringJobManager(
+                        storage
+                    ));
+                    services.AddHangfireMcp();
+                    services.AddRouting();
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapHangfireMcp("/mcp"));
+                });
+            });
+
+        _host = await builder.StartAsync();
+
+        var manager = _host.Services.GetRequiredService<IRecurringJobManager>();
+        manager.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily());
+
+        var testServer = _host.GetTestServer();
+        var http = testServer.CreateClient();
+        http.BaseAddress = new Uri(testServer.BaseAddress, "/mcp");
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions { Endpoint = http.BaseAddress },
+            http,
+            loggerFactory: null!,
+            ownsHttpClient: false
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _client.DisposeAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task ListPrompts_returns_maintenance_prompts()
+    {
+        var prompts = await _client.ListPromptsAsync();
+
+        prompts
+            .Select(p => p.Name)
+            .ShouldBe(
+                new[]
+                {
+                    MaintenancePrompts.Discover,
+                    MaintenancePrompts.HealthCheck,
+                    MaintenancePrompts.TriageFailures,
+                },
+                ignoreOrder: true
+            );
+    }
+
+    [Fact]
+    public async Task GetPrompt_health_check_returns_user_message()
+    {
+        var result = await _client.GetPromptAsync(MaintenancePrompts.HealthCheck);
+
+        result.Description.ShouldNotBeNullOrEmpty();
+        var msg = result.Messages.ShouldHaveSingleItem();
+        msg.Role.ShouldBe(Role.User);
+        msg.Content.ShouldBeOfType<TextContentBlock>()
+            .Text.ShouldContain("hangfire_get_statistics");
+    }
+
+    [Fact]
+    public async Task GetPrompt_discover_lists_tools()
+    {
+        var result = await _client.GetPromptAsync(MaintenancePrompts.Discover);
+
+        var text = result
+            .Messages.ShouldHaveSingleItem()
+            .Content.ShouldBeOfType<TextContentBlock>()
+            .Text;
+        text.ShouldContain("Run_nightly");
+        text.ShouldContain("hangfire_get_statistics");
+        text.ShouldContain("hangfire_list_jobs");
+    }
+
+    [Fact]
+    public async Task ListTools_still_includes_maintenance_and_discovered_tools()
+    {
+        var tools = await _client.ListToolsAsync();
+
+        var names = tools.Select(t => t.Name).ToArray();
+        names.ShouldContain("hangfire_get_statistics");
+        names.ShouldContain("Run_nightly");
+    }
+}

--- a/tests/Nall.Hangfire.Mcp.Tests/Tools/McpToolsIntegrationTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Tools/McpToolsIntegrationTests.cs
@@ -1,0 +1,166 @@
+using Hangfire;
+using Hangfire.InMemory;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using Nall.Hangfire.Mcp.Tests.Fixtures;
+using Shouldly;
+
+namespace Nall.Hangfire.Mcp.Tests.Tools;
+
+public class McpToolsIntegrationTests : IAsyncLifetime
+{
+    private IHost _host = null!;
+    private McpClient _client = null!;
+    private JobStorage _storage = null!;
+
+    public async Task InitializeAsync()
+    {
+        var storage = new InMemoryStorage();
+        _storage = storage;
+        JobStorage.Current = storage;
+
+        var builder = Host.CreateDefaultBuilder()
+            .ConfigureWebHost(web =>
+            {
+                web.UseTestServer();
+                web.ConfigureServices(services =>
+                {
+                    services.AddSingleton<JobStorage>(storage);
+                    services.AddSingleton<IBackgroundJobClient>(_ => new BackgroundJobClient(
+                        storage
+                    ));
+                    services.AddSingleton<IRecurringJobManager>(_ => new RecurringJobManager(
+                        storage
+                    ));
+                    services.AddHangfireMcp();
+                    services.AddRouting();
+                });
+                web.Configure(app =>
+                {
+                    app.UseRouting();
+                    app.UseEndpoints(e => e.MapHangfireMcp("/mcp"));
+                });
+            });
+
+        _host = await builder.StartAsync();
+
+        var manager = _host.Services.GetRequiredService<IRecurringJobManager>();
+        manager.AddOrUpdate<ReportJob>("nightly", j => j.GenerateAsync(2026, "pdf"), Cron.Daily());
+
+        var testServer = _host.GetTestServer();
+        var http = testServer.CreateClient();
+        http.BaseAddress = new Uri(testServer.BaseAddress, "/mcp");
+
+        var transport = new HttpClientTransport(
+            new HttpClientTransportOptions { Endpoint = http.BaseAddress },
+            http,
+            loggerFactory: null!,
+            ownsHttpClient: false
+        );
+        _client = await McpClient.CreateAsync(transport);
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _client.DisposeAsync();
+        _host.Dispose();
+    }
+
+    [Fact]
+    public async Task ListTools_returns_maintenance_and_run_job_tools()
+    {
+        var tools = await _client.ListToolsAsync();
+
+        var names = tools.Select(t => t.Name).ToArray();
+        names.ShouldContain("hangfire_get_statistics");
+        names.ShouldContain("hangfire_list_queues");
+        names.ShouldContain("hangfire_list_jobs");
+        names.ShouldContain("hangfire_get_job");
+        names.ShouldContain("hangfire_delete_job");
+        names.ShouldContain("hangfire_requeue_job");
+        names.ShouldContain("hangfire_delete_jobs");
+        names.ShouldContain("hangfire_requeue_jobs");
+        names.ShouldContain("Run_nightly");
+    }
+
+    [Fact]
+    public async Task CallTool_run_job_enqueues_hangfire_job()
+    {
+        var result = await _client.CallToolAsync(
+            "Run_nightly",
+            new Dictionary<string, object?> { ["year"] = 2030, ["format"] = "csv" }
+        );
+
+        (result.IsError ?? false).ShouldBeFalse();
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.ShouldStartWith("Enqueued Hangfire job ");
+
+        var monitor = _storage.GetMonitoringApi();
+        monitor.EnqueuedCount("default").ShouldBe(1);
+    }
+
+    [Fact]
+    public async Task CallTool_unknown_returns_error()
+    {
+        var result = await _client.CallToolAsync("Run_does_not_exist");
+
+        (result.IsError ?? false).ShouldBeTrue();
+        result.Content.OfType<TextContentBlock>().Single().Text.ShouldContain("Unknown tool");
+    }
+
+    [Fact]
+    public async Task CallTool_get_statistics_returns_counts()
+    {
+        var result = await _client.CallToolAsync("hangfire_get_statistics");
+
+        (result.IsError ?? false).ShouldBeFalse();
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.ShouldContain("Enqueued");
+        text.ShouldContain("Failed");
+        text.ShouldContain("Servers");
+    }
+
+    [Fact]
+    public async Task CallTool_list_jobs_returns_enqueued_after_dispatch()
+    {
+        await _client.CallToolAsync(
+            "Run_nightly",
+            new Dictionary<string, object?> { ["year"] = 2031 }
+        );
+
+        var result = await _client.CallToolAsync(
+            "hangfire_list_jobs",
+            new Dictionary<string, object?> { ["state"] = "Enqueued", ["count"] = 50 }
+        );
+
+        (result.IsError ?? false).ShouldBeFalse();
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.ShouldContain("ReportJob");
+    }
+
+    [Fact]
+    public async Task CallTool_delete_jobs_dryRun_does_not_remove()
+    {
+        var jobClient = _host.Services.GetRequiredService<IBackgroundJobClient>();
+        var jobId = jobClient.Enqueue<ReportJob>(j => j.GenerateAsync(2032, "pdf"));
+
+        var result = await _client.CallToolAsync(
+            "hangfire_delete_jobs",
+            new Dictionary<string, object?>
+            {
+                ["filter"] = new Dictionary<string, object?> { ["state"] = "Enqueued" },
+                ["dryRun"] = true,
+            }
+        );
+
+        (result.IsError ?? false).ShouldBeFalse();
+        _storage.GetMonitoringApi().EnqueuedCount("default").ShouldBe(1);
+        var text = result.Content.OfType<TextContentBlock>().Single().Text;
+        text.ShouldContain(jobId);
+    }
+}


### PR DESCRIPTION
Closes #4.

## Summary

Adds three MCP prompts under `Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs`:

- **`hangfire_discover`** — mindmap of what the server exposes: maintenance tools + dynamically-listed run-job tools (rendered from `JobCatalog`).
- **`hangfire_health_check`** — canonical tool sequence (`hangfire_get_statistics` + `hangfire_list_queues`) into a one-screen Backlog / Failures / Throughput / Verdict report.
- **`hangfire_triage_failures`** — group failures by `(jobType, exceptionType, message)`, classify Transient/Poison/Unknown, and enforce a `dryRun=true` → confirm → `dryRun=false` pattern before any destructive call.

Wired through `HangfireMcpServiceCollectionExtensions` via `WithListPromptsHandler` / `WithGetPromptHandler`. Prompts are static or catalog-only — no dynamic argument substitution.

## Test plan

- [x] Unit tests with Verify snapshots for each rendered prompt (`MaintenancePromptsTests`)
- [x] End-to-end MCP-client integration tests against in-memory Hangfire (`McpPromptsIntegrationTests`, `McpToolsIntegrationTests`) covering `prompts/list`, `prompts/get`, `tools/list`, `tools/call` (run-job, get_statistics, list_jobs, delete_jobs dryRun, unknown tool)
- [x] Full suite: 68/68 passing