### PR TITLE
feat: honor [Description] on jobs and parameters

### DIFF
--- a/samples/HangfireJobs/IDataExportJob.cs
+++ b/samples/HangfireJobs/IDataExportJob.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 
 namespace HangfireJobs;
@@ -11,7 +12,12 @@ public enum ExportFormat
 
 public interface IDataExportJob
 {
-    Task ExportAsync(ExportFormat format, IReadOnlyList<string> tables);
+    [Description("Export the named tables to the data lake in the requested format.")]
+    Task ExportAsync(
+        [Description("Serialization format used for the exported files.")] ExportFormat format,
+        [Description("Fully-qualified table names to include in the export.")]
+            IReadOnlyList<string> tables
+    );
 }
 
 public class DataExportJob(ILogger<DataExportJob> logger) : IDataExportJob

--- a/samples/HangfireJobs/INotificationJob.cs
+++ b/samples/HangfireJobs/INotificationJob.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 
 namespace HangfireJobs;
@@ -6,7 +7,15 @@ public interface INotificationJob
 {
     // channel is required (non-nullable reference); message and priority are nullable
     // and so optional in the MCP schema even though they have no C# default.
-    Task NotifyAsync(string channel, string? message, int? priority);
+    [Description(
+        "Send a notification to a specific channel with an optional message and priority."
+    )]
+    Task NotifyAsync(
+        [Description("Target channel name (e.g. 'ops-alerts').")] string channel,
+        [Description("Message body. If omitted, a default template is used.")] string? message,
+        [Description("Priority 1 (highest) to 5 (lowest). Defaults to 3 when omitted.")]
+            int? priority
+    );
 
     // Manifest-only candidate — never registered as recurring; one-shot enqueued in
     // Program.cs so the source generator records it. Optional `tag` (nullable) and

--- a/samples/HangfireJobs/IReportJob.cs
+++ b/samples/HangfireJobs/IReportJob.cs
@@ -1,10 +1,17 @@
+using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 
 namespace HangfireJobs;
 
 public interface IReportJob
 {
-    Task GenerateAsync(int year, string format = "pdf", DateTimeOffset? since = null);
+    [Description("Generate the annual financial report and persist it to the report store.")]
+    Task GenerateAsync(
+        [Description("Calendar year of the report (e.g. 2026).")] int year,
+        [Description("Output file format. Supported: pdf, html, csv.")] string format = "pdf",
+        [Description("Optional cutoff: only include data on or after this timestamp.")]
+            DateTimeOffset? since = null
+    );
 
     Task<int> PreviewAsync(int year);
 }

--- a/samples/HangfireJobs/MaintenanceJob.cs
+++ b/samples/HangfireJobs/MaintenanceJob.cs
@@ -1,10 +1,14 @@
+using System.ComponentModel;
 using Microsoft.Extensions.Logging;
 
 namespace HangfireJobs;
 
 public class MaintenanceJob(ILogger<MaintenanceJob> logger)
 {
-    public Task RebuildIndexesAsync(string schema = "public")
+    [Description("Rebuild all indexes in the given PostgreSQL schema.")]
+    public Task RebuildIndexesAsync(
+        [Description("Target schema name. Defaults to 'public'.")] string schema = "public"
+    )
     {
         logger.LogInformation("Rebuilding indexes in schema {Schema}", schema);
         return Task.CompletedTask;

--- a/src/Nall.Hangfire.Mcp/JobCatalog.cs
+++ b/src/Nall.Hangfire.Mcp/JobCatalog.cs
@@ -29,7 +29,8 @@ public sealed class JobCatalog
                 {
                     Name = d.ToolName,
                     Description =
-                        $"Enqueue Hangfire job '{d.RecurringJobId}' ({d.DeclaringType.Name}.{d.Method.Name}).",
+                        JobDescriptionResolver.ResolveMethod(d.Method)
+                        ?? $"Enqueue Hangfire job '{d.RecurringJobId}' ({d.DeclaringType.Name}.{d.Method.Name}).",
                     InputSchema = JobInputSchema.Build(d.Method),
                 })
                 .ToList(),

--- a/src/Nall.Hangfire.Mcp/JobDescriptionResolver.cs
+++ b/src/Nall.Hangfire.Mcp/JobDescriptionResolver.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Reflection;
+
+namespace Nall.Hangfire.Mcp;
+
+internal static class JobDescriptionResolver
+{
+    public static string? ResolveMethod(MethodInfo method)
+    {
+        ArgumentNullException.ThrowIfNull(method);
+
+        var direct = method.GetCustomAttribute<DescriptionAttribute>(inherit: true);
+        if (direct is not null)
+        {
+            return direct.Description;
+        }
+
+        foreach (var interfaceMethod in EnumerateInterfaceMethods(method))
+        {
+            var attr = interfaceMethod.GetCustomAttribute<DescriptionAttribute>(inherit: true);
+            if (attr is not null)
+            {
+                return attr.Description;
+            }
+        }
+
+        return null;
+    }
+
+    public static string? ResolveParameter(ParameterInfo parameter)
+    {
+        ArgumentNullException.ThrowIfNull(parameter);
+
+        var direct = parameter.GetCustomAttribute<DescriptionAttribute>(inherit: true);
+        if (direct is not null)
+        {
+            return direct.Description;
+        }
+
+        if (parameter.Member is not MethodInfo method)
+        {
+            return null;
+        }
+
+        var position = parameter.Position;
+        foreach (var interfaceMethod in EnumerateInterfaceMethods(method))
+        {
+            var ifaceParams = interfaceMethod.GetParameters();
+            if (position >= ifaceParams.Length)
+            {
+                continue;
+            }
+
+            var attr = ifaceParams[position]
+                .GetCustomAttribute<DescriptionAttribute>(inherit: true);
+            if (attr is not null)
+            {
+                return attr.Description;
+            }
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<MethodInfo> EnumerateInterfaceMethods(MethodInfo method)
+    {
+        var declaring = method.DeclaringType;
+        if (declaring is null || declaring.IsInterface)
+        {
+            yield break;
+        }
+
+        foreach (var iface in declaring.GetInterfaces())
+        {
+            InterfaceMapping map;
+            try
+            {
+                map = declaring.GetInterfaceMap(iface);
+            }
+            catch (ArgumentException)
+            {
+                continue;
+            }
+
+            for (var i = 0; i < map.TargetMethods.Length; i++)
+            {
+                if (map.TargetMethods[i] == method)
+                {
+                    yield return map.InterfaceMethods[i];
+                }
+            }
+        }
+    }
+}

--- a/src/Nall.Hangfire.Mcp/JobInputSchema.cs
+++ b/src/Nall.Hangfire.Mcp/JobInputSchema.cs
@@ -31,6 +31,11 @@ public static class JobInputSchema
             }
 
             var schema = JsonSchemaExporter.GetJsonSchemaAsNode(s_schemaOptions, p.ParameterType);
+            var description = JobDescriptionResolver.ResolveParameter(p);
+            if (!string.IsNullOrEmpty(description) && schema is JsonObject schemaObject)
+            {
+                schemaObject["description"] = description;
+            }
             properties[p.Name] = schema;
 
             if (!p.HasDefaultValue && !ParameterNullability.IsOptional(p, nullability))

--- a/tests/Nall.Hangfire.Mcp.Tests/Fixtures/JobFixtures.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Fixtures/JobFixtures.cs
@@ -1,7 +1,10 @@
+using System.ComponentModel;
+
 namespace Nall.Hangfire.Mcp.Tests.Fixtures;
 
 public interface IEmailJob
 {
+    [Description("Send a transactional email to the given recipient.")]
     Task SendAsync(string to);
 
     Task SendAsync(string to, string subject);
@@ -9,6 +12,7 @@ public interface IEmailJob
 
 public class ReportJob
 {
+    [Description("Generate the annual report.")]
     public Task GenerateAsync(int year, string format = "pdf") => Task.CompletedTask;
 
     public Task<int> CountRowsAsync() => Task.FromResult(0);
@@ -20,4 +24,27 @@ public class NullableJob
         Task.CompletedTask;
 
     public Task RefOnlyAsync(string requiredRef, string? optionalRef) => Task.CompletedTask;
+}
+
+public interface IDescribedJob
+{
+    [Description("Iface-level method description.")]
+    Task RunAsync([Description("Iface-level param description.")] string name, int count);
+}
+
+public class DescribedJob : IDescribedJob
+{
+    public Task RunAsync(string name, int count) => Task.CompletedTask;
+}
+
+public class DirectlyDescribedJob
+{
+    [Description("Direct method description.")]
+    public Task RunAsync([Description("Direct param description.")] string value) =>
+        Task.CompletedTask;
+}
+
+public class UndescribedJob
+{
+    public Task RunAsync(string value) => Task.CompletedTask;
 }

--- a/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
@@ -55,6 +55,41 @@ public class JobCatalogTests
     }
 
     [Fact]
+    public void Tool_description_falls_back_when_no_attribute_present()
+    {
+        var (storage, manager) = NewStorage();
+        manager.AddOrUpdate<UndescribedJob>("plain", j => j.RunAsync("a"), Cron.Daily());
+
+        var catalog = new JobCatalog(storage);
+
+        catalog
+            .ListToolsResult.Tools[0]
+            .Description.ShouldBe("Enqueue Hangfire job 'plain' (UndescribedJob.RunAsync).");
+    }
+
+    [Fact]
+    public void Tool_description_uses_interface_attribute_when_impl_undecorated()
+    {
+        var (storage, manager) = NewStorage();
+        manager.AddOrUpdate<DescribedJob>("desc", j => j.RunAsync("x", 1), Cron.Daily());
+
+        var catalog = new JobCatalog(storage);
+
+        catalog.ListToolsResult.Tools[0].Description.ShouldBe("Iface-level method description.");
+    }
+
+    [Fact]
+    public void Tool_description_uses_direct_attribute_on_method()
+    {
+        var (storage, manager) = NewStorage();
+        manager.AddOrUpdate<DirectlyDescribedJob>("direct", j => j.RunAsync("x"), Cron.Daily());
+
+        var catalog = new JobCatalog(storage);
+
+        catalog.ListToolsResult.Tools[0].Description.ShouldBe("Direct method description.");
+    }
+
+    [Fact]
     public void Snapshot_does_not_observe_jobs_added_after_construction()
     {
         var (storage, manager) = NewStorage();

--- a/tests/Nall.Hangfire.Mcp.Tests/JobInputSchemaTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobInputSchemaTests.cs
@@ -75,4 +75,50 @@ public class JobInputSchemaTests
     {
         Should.Throw<ArgumentNullException>(() => JobInputSchema.Build(null!));
     }
+
+    [Fact]
+    public void Build_emits_parameter_description_from_direct_attribute()
+    {
+        var method = typeof(DirectlyDescribedJob).GetMethod(nameof(DirectlyDescribedJob.RunAsync))!;
+
+        var schema = JobInputSchema.Build(method);
+        var doc = JsonDocument.Parse(schema.GetRawText()).RootElement;
+
+        doc.GetProperty("properties")
+            .GetProperty("value")
+            .GetProperty("description")
+            .GetString()
+            .ShouldBe("Direct param description.");
+    }
+
+    [Fact]
+    public void Build_emits_parameter_description_from_interface_fallback()
+    {
+        var method = typeof(DescribedJob).GetMethod(nameof(DescribedJob.RunAsync))!;
+
+        var schema = JobInputSchema.Build(method);
+        var doc = JsonDocument.Parse(schema.GetRawText()).RootElement;
+
+        var props = doc.GetProperty("properties");
+        props
+            .GetProperty("name")
+            .GetProperty("description")
+            .GetString()
+            .ShouldBe("Iface-level param description.");
+        props.GetProperty("count").TryGetProperty("description", out _).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Build_omits_description_when_no_attribute()
+    {
+        var method = typeof(UndescribedJob).GetMethod(nameof(UndescribedJob.RunAsync))!;
+
+        var schema = JobInputSchema.Build(method);
+        var doc = JsonDocument.Parse(schema.GetRawText()).RootElement;
+
+        doc.GetProperty("properties")
+            .GetProperty("value")
+            .TryGetProperty("description", out _)
+            .ShouldBeFalse();
+    }
 }

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -12,5 +12,5 @@ Hangfire MCP capabilities (mindmap):
   - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
   - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
 - Run jobs (tools)
-  - `Run_nightly` — Enqueue Hangfire job 'nightly' (ReportJob.GenerateAsync).
-  - `Run_send-welcome` — Enqueue Hangfire job 'send-welcome' (IEmailJob.SendAsync).
+  - `Run_nightly` — Generate the annual report.
+  - `Run_send-welcome` — Send a transactional email to the given recipient.


### PR DESCRIPTION
Closes #5.

## Summary
- Resolve `System.ComponentModel.DescriptionAttribute` on the registered method and its parameters when building the MCP tool list, falling back to the matching interface method via `Type.GetInterfaceMap` and finally to the existing synthetic string when no attribute is found.
- Per-parameter descriptions are merged into the JSON Schema (`properties.<name>.description`) so MCP clients show meaningful hints for inputs, mirroring how the MCP SDK handles `[McpServerTool]`.
- The existing `hangfire_discover` prompt picks up the new tool descriptions automatically (no prompt changes).
- No source-generator changes: both discovery paths (`RecurringStorage`, `StaticManifest`) end up with a real `MethodInfo`, so reflection covers them.

Sample jobs in `samples/HangfireJobs/` are decorated to demonstrate the behavior.

## Test plan
- [x] `dotnet build hangfire-mcp-dotnet.slnx -p:WarningLevel=0 /clp:ErrorsOnly`
- [x] `dotnet test hangfire-mcp-dotnet.slnx` — 74 passed (6 new tests covering direct attribute, interface fallback, and undecorated branches; verify snapshot updated to exercise the new path)
- [x] Manual: `aspire run` then inspect `GET /jobs` and a `tools/list` MCP call