### PR TITLE
feat: expression-delegate job discovery + CancellationToken support

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ Every MCP server hosted by `AddHangfireMcp()` also exposes a fixed set of `hangf
 | Tool                      | Purpose                                                                                            |
 | ------------------------- | -------------------------------------------------------------------------------------------------- |
 | `hangfire_get_statistics` | Global counters: Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries/Servers. |
-| `hangfire_list_queues`    | Per-queue length + sample of first enqueued jobs.                                                  |
 | `hangfire_list_jobs`      | Page jobs by `state` with optional filter. Use this to discover ids before bulk ops.               |
 | `hangfire_get_job`        | Full details + state history for one id.                                                           |
 | `hangfire_delete_job`     | Move one job to Deleted.                                                                           |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -58,7 +58,6 @@ Every MCP server hosted by `AddHangfireMcp()` also exposes a fixed set of `hangf
 | Tool                      | Purpose                                                                                            |
 | ------------------------- | -------------------------------------------------------------------------------------------------- |
 | `hangfire_get_statistics` | Global counters: Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries/Servers. |
-| `hangfire_list_queues`    | Per-queue length + sample of first enqueued jobs.                                                  |
 | `hangfire_list_jobs`      | Page jobs by `state` with optional filter. Use this to discover ids before bulk ops.               |
 | `hangfire_get_job`        | Full details + state history for one id.                                                           |
 | `hangfire_delete_job`     | Move one job to Deleted.                                                                           |

--- a/src/Nall.Hangfire.Mcp.Generator/HangfireRegistrationGenerator.cs
+++ b/src/Nall.Hangfire.Mcp.Generator/HangfireRegistrationGenerator.cs
@@ -85,6 +85,25 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         return s_registrationMethodNames.Contains(name);
     }
 
+    // Accepts any method whose registered-name shape is a Hangfire-style wrapper:
+    // it forwards a job lambda via System.Linq.Expressions.Expression<TDelegate>.
+    private static bool HasExpressionDelegateParameter(IMethodSymbol method)
+    {
+        foreach (var p in method.Parameters)
+        {
+            if (
+                p.Type is INamedTypeSymbol { IsGenericType: true } named
+                && named.OriginalDefinition.Name == "Expression"
+                && named.OriginalDefinition.ContainingNamespace?.ToDisplayString()
+                    == "System.Linq.Expressions"
+            )
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private static Entry? Extract(GeneratorSyntaxContext ctx)
     {
         var inv = (InvocationExpressionSyntax)ctx.Node;
@@ -97,7 +116,9 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         }
 
         var containing = method.ContainingType?.ToDisplayString();
-        if (containing is null || !s_hangfireContainingTypes.Contains(containing))
+        var isHangfireApi =
+            containing is not null && s_hangfireContainingTypes.Contains(containing);
+        if (!isHangfireApi && !HasExpressionDelegateParameter(method))
         {
             return null;
         }
@@ -172,9 +193,19 @@ public sealed class HangfireRegistrationGenerator : IIncrementalGenerator
         sb.AppendLine("        [System.Runtime.CompilerServices.ModuleInitializer]");
         sb.AppendLine("        internal static void Register()");
         sb.AppendLine("        {");
-        sb.AppendLine("            global::Nall.Hangfire.Mcp.Manifest.JobManifestRegistry.Add(");
-        sb.AppendLine("                typeof(HangfireJobManifest).Assembly,");
-        sb.AppendLine("                Entries);");
+        sb.AppendLine(
+            "            // Reflection-based to avoid forcing consumers to reference Nall.Hangfire.Mcp at compile time."
+        );
+        sb.AppendLine(
+            "            var registry = System.Type.GetType(\"Nall.Hangfire.Mcp.Manifest.JobManifestRegistry, Nall.Hangfire.Mcp\", throwOnError: false);"
+        );
+        sb.AppendLine("            if (registry is null) { return; }");
+        sb.AppendLine(
+            "            var add = registry.GetMethod(\"Add\", new System.Type[] { typeof(System.Reflection.Assembly), typeof((System.Type, string, System.Type[])[]) });"
+        );
+        sb.AppendLine(
+            "            add?.Invoke(null, new object[] { typeof(HangfireJobManifest).Assembly, Entries });"
+        );
         sb.AppendLine("        }");
         sb.AppendLine();
         sb.AppendLine(

--- a/src/Nall.Hangfire.Mcp/JobArgumentBinder.cs
+++ b/src/Nall.Hangfire.Mcp/JobArgumentBinder.cs
@@ -21,6 +21,11 @@ public static class JobArgumentBinder
         for (var i = 0; i < parameters.Length; i++)
         {
             var p = parameters[i];
+            if (JobParameterFilter.IsCancellationToken(p))
+            {
+                bound[i] = CancellationToken.None;
+                continue;
+            }
             if (
                 p.Name is not null
                 && arguments is not null

--- a/src/Nall.Hangfire.Mcp/JobCatalog.cs
+++ b/src/Nall.Hangfire.Mcp/JobCatalog.cs
@@ -30,7 +30,7 @@ public sealed class JobCatalog
                     Name = d.ToolName,
                     Description =
                         JobDescriptionResolver.ResolveMethod(d.Method)
-                        ?? $"Enqueue Hangfire job '{d.RecurringJobId}'.",
+                        ?? $"Enqueue Hangfire job '{d.RecurringJobId}'",
                     InputSchema = JobInputSchema.Build(d.Method),
                 })
                 .ToList(),

--- a/src/Nall.Hangfire.Mcp/JobCatalog.cs
+++ b/src/Nall.Hangfire.Mcp/JobCatalog.cs
@@ -30,7 +30,7 @@ public sealed class JobCatalog
                     Name = d.ToolName,
                     Description =
                         JobDescriptionResolver.ResolveMethod(d.Method)
-                        ?? $"Enqueue Hangfire job '{d.RecurringJobId}' ({d.DeclaringType.Name}.{d.Method.Name}).",
+                        ?? $"Enqueue Hangfire job '{d.RecurringJobId}'.",
                     InputSchema = JobInputSchema.Build(d.Method),
                 })
                 .ToList(),

--- a/src/Nall.Hangfire.Mcp/JobInputSchema.cs
+++ b/src/Nall.Hangfire.Mcp/JobInputSchema.cs
@@ -29,6 +29,10 @@ public static class JobInputSchema
             {
                 continue;
             }
+            if (JobParameterFilter.IsCancellationToken(p))
+            {
+                continue;
+            }
 
             var schema = JsonSchemaExporter.GetJsonSchemaAsNode(s_schemaOptions, p.ParameterType);
             var description = JobDescriptionResolver.ResolveParameter(p);

--- a/src/Nall.Hangfire.Mcp/JobParameterFilter.cs
+++ b/src/Nall.Hangfire.Mcp/JobParameterFilter.cs
@@ -1,0 +1,9 @@
+using System.Reflection;
+
+namespace Nall.Hangfire.Mcp;
+
+internal static class JobParameterFilter
+{
+    public static bool IsCancellationToken(ParameterInfo p) =>
+        p.ParameterType == typeof(CancellationToken);
+}

--- a/src/Nall.Hangfire.Mcp/Maintenance/JobFilter.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/JobFilter.cs
@@ -18,4 +18,6 @@ public sealed record JobFilter
     public string? Method { get; init; }
     public string? MessageContains { get; init; }
     public string? ExceptionContains { get; init; }
+    public DateTime? Since { get; init; }
+    public DateTime? Until { get; init; }
 }

--- a/src/Nall.Hangfire.Mcp/Maintenance/JobFilterMatcher.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/JobFilterMatcher.cs
@@ -47,6 +47,16 @@ public static class JobFilterMatcher
             }
         }
 
+        if (filter.Since is { } since && (match.At is null || match.At < since))
+        {
+            return false;
+        }
+
+        if (filter.Until is { } until && (match.At is null || match.At > until))
+        {
+            return false;
+        }
+
         return true;
     }
 

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
@@ -91,7 +91,7 @@ public sealed class MaintenanceDispatcher
                 Id = id,
                 Type = dto.Job?.Type?.FullName,
                 Method = dto.Job?.Method?.Name,
-                Args = dto.Job?.Args,
+                Args = dto.Job?.Args?.Select(SafeRenderArg).ToArray(),
                 Properties = dto.Properties,
                 ExpireAt = dto.ExpireAt,
                 CreatedAt = dto.CreatedAt,
@@ -252,6 +252,8 @@ public sealed class MaintenanceDispatcher
         new
         {
             m.Id,
+            State = m.State.ToString(),
+            m.At,
             Type = m.Job?.Type?.FullName,
             Method = m.Job?.Method?.Name,
             m.Queue,
@@ -259,6 +261,26 @@ public sealed class MaintenanceDispatcher
             m.ExceptionType,
             m.ExceptionMessage,
         };
+
+    private static object? SafeRenderArg(object? arg)
+    {
+        if (arg is null)
+        {
+            return null;
+        }
+        if (arg is CancellationToken)
+        {
+            return "<CancellationToken>";
+        }
+        try
+        {
+            return JsonSerializer.SerializeToElement(arg, s_json);
+        }
+        catch (NotSupportedException)
+        {
+            return arg.GetType().FullName;
+        }
+    }
 
     private static CallToolResult Json(object payload) =>
         new()

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceDispatcher.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using ModelContextProtocol.Protocol;
@@ -36,8 +37,7 @@ public sealed class MaintenanceDispatcher
             var args = @params?.Arguments?.AsReadOnly();
             return name switch
             {
-                MaintenanceTools.GetStatistics => Json(ProjectStatistics(_query.GetStatistics())),
-                MaintenanceTools.ListQueues => Json(ProjectQueues(_query.ListQueues())),
+                MaintenanceTools.GetStatistics => HandleGetStatistics(args),
                 MaintenanceTools.ListJobs => HandleListJobs(args),
                 MaintenanceTools.GetJob => HandleGetJob(args),
                 MaintenanceTools.DeleteJob => HandleDeleteJob(args),
@@ -52,6 +52,31 @@ public sealed class MaintenanceDispatcher
         {
             return Error(ex.Message);
         }
+    }
+
+    private CallToolResult HandleGetStatistics(IReadOnlyDictionary<string, JsonElement>? args)
+    {
+        var windowHours = ReadIntInRange(args, "windowHours", 24, 1, 168);
+        var recentLimit = ReadIntInRange(args, "recentLimit", 20, 1, 100);
+        var groupScan = ReadIntInRange(args, "groupScan", 100, 1, 500);
+        var rich = _query.GetStatisticsRich(windowHours, recentLimit, groupScan);
+        return Json(ProjectStatisticsRich(rich));
+    }
+
+    private static int ReadIntInRange(
+        IReadOnlyDictionary<string, JsonElement>? args,
+        string key,
+        int @default,
+        int min,
+        int max
+    )
+    {
+        var value = ReadInt(args, key) ?? @default;
+        if (value < min || value > max)
+        {
+            throw new ArgumentException($"'{key}' must be between {min} and {max}.");
+        }
+        return value;
     }
 
     private CallToolResult HandleListJobs(IReadOnlyDictionary<string, JsonElement>? args)
@@ -154,6 +179,8 @@ public sealed class MaintenanceDispatcher
             Method = ReadStringProp(el, "method"),
             MessageContains = ReadStringProp(el, "messageContains"),
             ExceptionContains = ReadStringProp(el, "exceptionContains"),
+            Since = ReadDateTimeProp(el, "since"),
+            Until = ReadDateTimeProp(el, "until"),
         };
     }
 
@@ -166,6 +193,26 @@ public sealed class MaintenanceDispatcher
         obj.TryGetProperty(key, out var v) && v.ValueKind == JsonValueKind.String
             ? v.GetString()
             : null;
+
+    private static DateTime? ReadDateTimeProp(JsonElement obj, string key)
+    {
+        if (
+            !obj.TryGetProperty(key, out var v)
+            || v.ValueKind != JsonValueKind.String
+            || v.GetString() is not { } s
+        )
+        {
+            return null;
+        }
+        return DateTime.TryParse(
+            s,
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+            out var dt
+        )
+            ? dt
+            : null;
+    }
 
     private static int? ReadInt(IReadOnlyDictionary<string, JsonElement>? args, string key) =>
         args is not null && args.TryGetValue(key, out var v) && v.ValueKind == JsonValueKind.Number
@@ -218,35 +265,39 @@ public sealed class MaintenanceDispatcher
             ? v
             : null;
 
-    private static object ProjectStatistics(global::Hangfire.Storage.Monitoring.StatisticsDto s) =>
+    private static object ProjectStatisticsRich(StatisticsResult r) =>
         new
         {
-            s.Servers,
-            s.Queues,
-            s.Enqueued,
-            s.Failed,
-            s.Processing,
-            s.Scheduled,
-            s.Succeeded,
-            s.Deleted,
-            s.Recurring,
-            s.Retries,
-        };
-
-    private static object ProjectQueues(
-        IList<global::Hangfire.Storage.Monitoring.QueueWithTopEnqueuedJobsDto> queues
-    ) =>
-        queues
-            .Select(q => new
+            now = r.Now,
+            counts = new
             {
-                q.Name,
-                q.Length,
-                q.Fetched,
-                FirstJobs = q
-                    .FirstJobs.Select(j => new { Id = j.Key, Type = j.Value.Job?.Type?.FullName })
-                    .ToArray(),
-            })
-            .ToArray();
+                r.Counts.Servers,
+                r.Counts.Queues,
+                r.Counts.Enqueued,
+                r.Counts.Failed,
+                r.Counts.Processing,
+                r.Counts.Scheduled,
+                r.Counts.Succeeded,
+                r.Counts.Deleted,
+                r.Counts.Recurring,
+                r.Counts.Retries,
+            },
+            trend24h = new { r.Trend.Succeeded, r.Trend.Failed },
+            r.WindowHours,
+            r.FailedInWindow,
+            failureGroups = r.FailureGroups.Count == 0 ? null : (object)r.FailureGroups,
+            recentFailedIds = r.RecentFailedIds.Count == 0 ? null : (object)r.RecentFailedIds,
+            servers = r
+                .Servers.Select(s => new
+                {
+                    s.Name,
+                    s.Heartbeat,
+                    s.WorkersCount,
+                    s.Queues,
+                    s.StartedAt,
+                })
+                .ToArray(),
+        };
 
     private static object ProjectMatch(JobMatch m) =>
         new

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
@@ -146,38 +146,48 @@ public sealed class MaintenanceQueryService
             JobStateKind.Enqueued => FetchEnqueued(from, count),
             JobStateKind.Processing => Project(
                 Api.ProcessingJobs(from, count),
+                state,
                 d => d.Job,
                 _ => null,
                 _ => null,
-                _ => null
+                _ => null,
+                d => d.StartedAt
             ),
             JobStateKind.Scheduled => Project(
                 Api.ScheduledJobs(from, count),
+                state,
                 d => d.Job,
                 _ => null,
                 _ => null,
-                _ => null
+                _ => null,
+                d => d.ScheduledAt
             ),
             JobStateKind.Failed => Project(
                 Api.FailedJobs(from, count),
+                state,
                 d => d.Job,
                 d => d.Reason,
                 d => d.ExceptionType,
-                d => d.ExceptionMessage
+                d => d.ExceptionMessage,
+                d => d.FailedAt
             ),
             JobStateKind.Succeeded => Project(
                 Api.SucceededJobs(from, count),
+                state,
                 d => d.Job,
                 _ => null,
                 _ => null,
-                _ => null
+                _ => null,
+                d => d.SucceededAt
             ),
             JobStateKind.Deleted => Project(
                 Api.DeletedJobs(from, count),
+                state,
                 d => d.Job,
                 _ => null,
                 _ => null,
-                _ => null
+                _ => null,
+                d => d.DeletedAt
             ),
             _ => Array.Empty<JobMatch>(),
         };
@@ -202,7 +212,17 @@ public sealed class MaintenanceQueryService
             var pageCount = Math.Min(take, len - skip);
             foreach (var kvp in Api.EnqueuedJobs(queue.Name, skip, pageCount))
             {
-                results.Add(new JobMatch(kvp.Key, kvp.Value.Job, queue.Name, null, null, null));
+                results.Add(
+                    new JobMatch(
+                        kvp.Key,
+                        kvp.Value.Job,
+                        queue.Name,
+                        null,
+                        null,
+                        null,
+                        JobStateKind.Enqueued
+                    )
+                );
             }
             take -= pageCount;
             skip = 0;
@@ -212,24 +232,29 @@ public sealed class MaintenanceQueryService
 
     private static IReadOnlyList<JobMatch> Project<T>(
         JobList<T> list,
+        JobStateKind state,
         Func<T, Job?> getJob,
         Func<T, string?> getReason,
         Func<T, string?> getExceptionType,
-        Func<T, string?> getExceptionMessage
+        Func<T, string?> getExceptionMessage,
+        Func<T, DateTime?> getAt
     )
     {
         var results = new List<JobMatch>(list.Count);
         foreach (var kvp in list)
         {
             var dto = kvp.Value;
+            var job = getJob(dto);
             results.Add(
                 new JobMatch(
                     kvp.Key,
-                    getJob(dto),
-                    getJob(dto)?.Queue,
+                    job,
+                    job?.Queue,
                     getReason(dto),
                     getExceptionType(dto),
-                    getExceptionMessage(dto)
+                    getExceptionMessage(dto),
+                    state,
+                    getAt(dto)
                 )
             );
         }
@@ -243,7 +268,9 @@ public sealed record JobMatch(
     string? Queue,
     string? Reason,
     string? ExceptionType,
-    string? ExceptionMessage
+    string? ExceptionMessage,
+    JobStateKind State,
+    DateTime? At = null
 );
 
 public sealed record ScanResult(

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceQueryService.cs
@@ -8,6 +8,7 @@ namespace Nall.Hangfire.Mcp.Maintenance;
 public sealed class MaintenanceQueryService
 {
     private const int PageSize = 1000;
+    private const string Unknown = "(unknown)";
 
     private readonly JobStorage _storage;
 
@@ -21,7 +22,128 @@ public sealed class MaintenanceQueryService
 
     public StatisticsDto GetStatistics() => Api.GetStatistics();
 
-    public IList<QueueWithTopEnqueuedJobsDto> ListQueues() => Api.Queues();
+    public StatisticsResult GetStatisticsRich(int windowHours, int recentLimit, int groupScan)
+    {
+        var api = Api;
+        var counts = api.GetStatistics();
+        var now = DateTime.UtcNow;
+        var since = now.AddHours(-windowHours);
+
+        var hourlySucceeded = SafeHourly(api.HourlySucceededJobs);
+        var hourlyFailed = SafeHourly(api.HourlyFailedJobs);
+        var trend = new Trend24h(SumLast(hourlySucceeded, since), SumLast(hourlyFailed, since));
+
+        var recentFailedIds = new List<string>();
+        var groups = new Dictionary<(string, string), FailureGroupAcc>(capacity: 8, comparer: null);
+        var failedInWindow = 0;
+
+        if (counts.Failed > 0)
+        {
+            var sample = api.FailedJobs(0, Math.Min(groupScan, (int)counts.Failed));
+            foreach (var kvp in sample)
+            {
+                var dto = kvp.Value;
+                if (dto.FailedAt is { } at && at < since)
+                {
+                    continue;
+                }
+                failedInWindow++;
+                if (recentFailedIds.Count < recentLimit)
+                {
+                    recentFailedIds.Add(kvp.Key);
+                }
+                var jobType = dto.Job?.Type;
+                var typeName = jobType?.FullName ?? jobType?.Name ?? Unknown;
+                var exType = dto.ExceptionType ?? Unknown;
+                var key = (typeName, exType);
+                if (!groups.TryGetValue(key, out var acc))
+                {
+                    acc = new FailureGroupAcc(
+                        typeName,
+                        exType,
+                        kvp.Key,
+                        dto.FailedAt,
+                        dto.FailedAt
+                    );
+                }
+                acc = acc with
+                {
+                    Count = acc.Count + 1,
+                    OldestAt =
+                        dto.FailedAt is { } a && (acc.OldestAt is null || a < acc.OldestAt)
+                            ? a
+                            : acc.OldestAt,
+                    NewestAt =
+                        dto.FailedAt is { } b && (acc.NewestAt is null || b > acc.NewestAt)
+                            ? b
+                            : acc.NewestAt,
+                };
+                groups[key] = acc;
+            }
+        }
+
+        var failureGroups = groups
+            .Values.OrderByDescending(g => g.Count)
+            .Take(5)
+            .Select(g => new FailureGroup(
+                g.Type,
+                g.Exception,
+                g.Count,
+                g.SampleId,
+                g.OldestAt,
+                g.NewestAt
+            ))
+            .ToList();
+
+        var servers = api.Servers()
+            .Select(s => new ServerInfo(s.Name, s.Heartbeat, s.WorkersCount, s.Queues, s.StartedAt))
+            .ToList();
+
+        return new StatisticsResult(
+            now,
+            counts,
+            trend,
+            failedInWindow,
+            failureGroups,
+            recentFailedIds,
+            servers,
+            windowHours
+        );
+    }
+
+    private static IDictionary<DateTime, long> SafeHourly(Func<IDictionary<DateTime, long>> fn)
+    {
+        try
+        {
+            return fn() ?? new Dictionary<DateTime, long>();
+        }
+        catch
+        {
+            return new Dictionary<DateTime, long>();
+        }
+    }
+
+    private static long SumLast(IDictionary<DateTime, long> series, DateTime since)
+    {
+        long total = 0;
+        foreach (var (k, v) in series)
+        {
+            if (k >= since)
+            {
+                total += v;
+            }
+        }
+        return total;
+    }
+
+    private sealed record FailureGroupAcc(
+        string Type,
+        string Exception,
+        string SampleId,
+        DateTime? OldestAt,
+        DateTime? NewestAt,
+        int Count = 1
+    );
 
     public JobDetailsDto? GetJob(string id) => Api.JobDetails(id);
 
@@ -279,4 +401,34 @@ public sealed record ScanResult(
     long StateTotal,
     bool Truncated,
     int NextFrom
+);
+
+public sealed record StatisticsResult(
+    DateTime Now,
+    StatisticsDto Counts,
+    Trend24h Trend,
+    int FailedInWindow,
+    IReadOnlyList<FailureGroup> FailureGroups,
+    IReadOnlyList<string> RecentFailedIds,
+    IReadOnlyList<ServerInfo> Servers,
+    int WindowHours
+);
+
+public sealed record Trend24h(long Succeeded, long Failed);
+
+public sealed record FailureGroup(
+    string Type,
+    string Exception,
+    int Count,
+    string SampleId,
+    DateTime? OldestAt,
+    DateTime? NewestAt
+);
+
+public sealed record ServerInfo(
+    string Name,
+    DateTime? Heartbeat,
+    int WorkersCount,
+    IList<string> Queues,
+    DateTime StartedAt
 );

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
@@ -42,34 +42,33 @@ public static class MaintenanceTools
             {
                 Name = GetJob,
                 Description =
-                    "Return full details for a single Hangfire job: type, method, args, properties, and state history.",
+                    "Return full details for a single Hangfire job: type, method, args, properties, and state history",
                 InputSchema = JobIdSchema(),
             },
             new Tool
             {
                 Name = DeleteJob,
-                Description = "Move a single job to the Deleted state.",
+                Description = "Move a single job to the Deleted state",
                 InputSchema = JobIdSchema(),
             },
             new Tool
             {
                 Name = RequeueJob,
-                Description =
-                    "Requeue a single job back to Enqueued (covers retry of Failed jobs).",
+                Description = "Requeue a single job back to Enqueued (covers retry of Failed jobs)",
                 InputSchema = JobIdSchema(),
             },
             new Tool
             {
                 Name = DeleteJobs,
                 Description =
-                    "Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.",
+                    "Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize",
                 InputSchema = BulkSchema(),
             },
             new Tool
             {
                 Name = RequeueJobs,
                 Description =
-                    "Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.",
+                    "Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize",
                 InputSchema = BulkSchema(),
             },
         };

--- a/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
+++ b/src/Nall.Hangfire.Mcp/Maintenance/MaintenanceTools.cs
@@ -9,7 +9,6 @@ public static class MaintenanceTools
     public const string Prefix = "hangfire_";
 
     public const string GetStatistics = "hangfire_get_statistics";
-    public const string ListQueues = "hangfire_list_queues";
     public const string ListJobs = "hangfire_list_jobs";
     public const string GetJob = "hangfire_get_job";
     public const string DeleteJob = "hangfire_delete_job";
@@ -29,21 +28,14 @@ public static class MaintenanceTools
             {
                 Name = GetStatistics,
                 Description =
-                    "Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.",
-                InputSchema = EmptyObject(),
-            },
-            new Tool
-            {
-                Name = ListQueues,
-                Description =
-                    "List Hangfire queues with their lengths and a sample of first enqueued jobs.",
-                InputSchema = EmptyObject(),
+                    "Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage",
+                InputSchema = StatisticsSchema(),
             },
             new Tool
             {
                 Name = ListJobs,
                 Description =
-                    "Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue.",
+                    "Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue",
                 InputSchema = ListJobsSchema(),
             },
             new Tool
@@ -82,8 +74,42 @@ public static class MaintenanceTools
             },
         };
 
-    private static JsonElement EmptyObject() =>
-        ToElement(new JsonObject { ["type"] = "object", ["properties"] = new JsonObject() });
+    private static JsonElement StatisticsSchema() =>
+        ToElement(
+            new JsonObject
+            {
+                ["type"] = "object",
+                ["properties"] = new JsonObject
+                {
+                    ["windowHours"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["minimum"] = 1,
+                        ["maximum"] = 168,
+                        ["default"] = 24,
+                        ["description"] =
+                            "Lookback window for failedInWindow / failureGroups / recentFailedIds.",
+                    },
+                    ["recentLimit"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["minimum"] = 1,
+                        ["maximum"] = 100,
+                        ["default"] = 20,
+                        ["description"] = "Max ids returned in recentFailedIds.",
+                    },
+                    ["groupScan"] = new JsonObject
+                    {
+                        ["type"] = "integer",
+                        ["minimum"] = 1,
+                        ["maximum"] = 500,
+                        ["default"] = 100,
+                        ["description"] =
+                            "How many recent Failed jobs to scan when computing failureGroups.",
+                    },
+                },
+            }
+        );
 
     private static JsonElement JobIdSchema() =>
         ToElement(
@@ -179,6 +205,19 @@ public static class MaintenanceTools
                 ["type"] = "string",
                 ["description"] =
                     "Substring match against ExceptionType / ExceptionMessage (Failed only).",
+            },
+            ["since"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["format"] = "date-time",
+                ["description"] =
+                    "Inclusive lower bound on the state-transition timestamp (e.g. FailedAt for Failed). ISO-8601 UTC. Jobs with no timestamp (Enqueued) are excluded when set.",
+            },
+            ["until"] = new JsonObject
+            {
+                ["type"] = "string",
+                ["format"] = "date-time",
+                ["description"] = "Inclusive upper bound on the state-transition timestamp.",
             },
         };
         var schema = new JsonObject { ["type"] = "object", ["properties"] = props };

--- a/src/Nall.Hangfire.Mcp/Manifest/JobManifestRegistry.cs
+++ b/src/Nall.Hangfire.Mcp/Manifest/JobManifestRegistry.cs
@@ -10,10 +10,11 @@ public static class JobManifestRegistry
 
     public static void Add(
         Assembly source,
-        ReadOnlySpan<(Type Type, string Method, Type[] ParameterTypes)> entries
+        (Type Type, string Method, Type[] ParameterTypes)[] entries
     )
     {
         ArgumentNullException.ThrowIfNull(source);
+        ArgumentNullException.ThrowIfNull(entries);
 
         var resolved = new List<JobDescriptor>(entries.Length);
         foreach (var (type, method, paramTypes) in entries)

--- a/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
+++ b/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
@@ -106,7 +106,12 @@ public static class MaintenancePrompts
         }
         else
         {
-            foreach (var tool in catalog.ListToolsResult.Tools)
+            foreach (
+                var tool in catalog.ListToolsResult.Tools.OrderBy(
+                    t => t.Name,
+                    StringComparer.Ordinal
+                )
+            )
             {
                 sb.AppendLine($"  - `{tool.Name}` — {tool.Description}");
             }

--- a/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
+++ b/src/Nall.Hangfire.Mcp/Prompts/MaintenancePrompts.cs
@@ -54,18 +54,16 @@ public static class MaintenancePrompts
     private static GetPromptResult RenderHealthCheck()
     {
         const string text = """
-            You are a Hangfire operations assistant. Produce a one-screen health report by following these steps:
+            You are a Hangfire operations assistant. Produce a one-screen health report.
 
-            1. Call tool `hangfire_get_statistics` to retrieve global counters.
-            2. Call tool `hangfire_list_queues` to inspect per-queue lengths.
-            3. Synthesize a structured report with these sections:
-               - **Backlog**: Enqueued + Scheduled totals; flag if any single queue length exceeds 1000.
-               - **Failures**: Failed count and Retries; flag if Failed > 50 or > 1% of Succeeded.
-               - **Throughput**: Processing count vs Servers; flag if Processing > 0 but Servers = 0.
-               - **Recurring**: Recurring count.
-               - **Verdict**: a single line — "Healthy", "Degraded", or "Unhealthy" — with the dominant reason.
+            1. Call `hangfire_get_statistics` (single call gives counters, 24h trend, servers, recent failure groups).
+            2. Synthesize:
+               - **Backlog**: Enqueued + Scheduled.
+               - **Failures**: Failed + failedInWindow; flag dominant failureGroups.
+               - **Throughput**: Processing vs servers.WorkersCount; flag Processing > 0 with no live servers.
+               - **Verdict**: one line — "Healthy" | "Degraded" | "Unhealthy" + dominant reason.
 
-            Do not call any destructive tool (`hangfire_delete_*`, `hangfire_requeue_*`). This prompt is read-only.
+            Read-only: do not call `hangfire_delete_*` or `hangfire_requeue_*`.
             """;
         return TextUserPrompt("Hangfire operational health summary.", text);
     }
@@ -73,18 +71,17 @@ public static class MaintenancePrompts
     private static GetPromptResult RenderTriageFailures()
     {
         const string text = """
-            You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend a remediation per failure group.
+            You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend remediation per failure group.
 
             Steps:
-            1. Call `hangfire_list_jobs` with `state="Failed"`, `count=100`. Optionally narrow with `filter.jobType` if the user named a specific job.
-            2. Group results by `(jobType, exceptionType, first 80 chars of exceptionMessage)`. Sort by group size descending.
-            3. For each group, call `hangfire_get_job` on one representative id to fetch full state history.
-            4. Classify each group:
-               - **Transient** (timeout, network, 5xx, deadlock) → recommend **requeue**.
-               - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → recommend **delete**.
-               - **Unknown** → recommend manual investigation, do not act.
-            5. Present a markdown table: jobType | exception | count | recommendation | reasoning.
-            6. SAFETY: Before any destructive action, you MUST first call `hangfire_delete_jobs` or `hangfire_requeue_jobs` with `dryRun=true` and the same filter, show the matched ids to the user, and explicitly ask for confirmation. Only call again with `dryRun=false` after the user confirms.
+            1. Call `hangfire_get_statistics` — `failureGroups` already aggregates by (type, exception) with a sample id.
+            2. For each group, call `hangfire_get_job` on the sample id for full state history. Narrow further with `hangfire_list_jobs` (state="Failed", filter.jobType / filter.exceptionContains / filter.since) only if needed.
+            3. Classify:
+               - **Transient** (timeout, network, 5xx, deadlock) → **requeue**.
+               - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → **delete**.
+               - **Unknown** → manual investigation, do not act.
+            4. Present a markdown table: jobType | exception | count | recommendation | reasoning.
+            5. SAFETY: Before any destructive call, run `hangfire_delete_jobs`/`hangfire_requeue_jobs` with `dryRun=true` and the same filter, show matched ids, and wait for explicit user confirmation before calling again with `dryRun=false`.
             """;
         return TextUserPrompt("Triage Hangfire failure groups.", text);
     }

--- a/tests/Nall.Hangfire.Mcp.Tests/Fixtures/JobFixtures.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Fixtures/JobFixtures.cs
@@ -55,6 +55,13 @@ public class OpenJob
     public Task RunAsync() => Task.CompletedTask;
 }
 
+public class CancellationTokenJob
+{
+    public Task RunAsync(string name, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task TokenOnlyAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}
+
 public class SameArityOverloadsJob
 {
     public Task RunAsync(int value) => Task.CompletedTask;

--- a/tests/Nall.Hangfire.Mcp.Tests/JobArgumentBinderTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobArgumentBinderTests.cs
@@ -66,6 +66,41 @@ public class JobArgumentBinderTests
     }
 
     [Fact]
+    public void Binds_cancellation_token_to_none_without_user_input()
+    {
+        var method = typeof(CancellationTokenJob).GetMethod(nameof(CancellationTokenJob.RunAsync))!;
+
+        var bound = JobArgumentBinder.Bind(method, Args("""{"name": "x"}"""));
+
+        bound.ShouldBe(["x", CancellationToken.None]);
+    }
+
+    [Fact]
+    public void Binds_cancellation_token_only_method_without_arguments()
+    {
+        var method = typeof(CancellationTokenJob).GetMethod(
+            nameof(CancellationTokenJob.TokenOnlyAsync)
+        )!;
+
+        var bound = JobArgumentBinder.Bind(method, arguments: null);
+
+        bound.ShouldBe([CancellationToken.None]);
+    }
+
+    [Fact]
+    public void Ignores_user_supplied_cancellation_token_argument()
+    {
+        var method = typeof(CancellationTokenJob).GetMethod(nameof(CancellationTokenJob.RunAsync))!;
+
+        var bound = JobArgumentBinder.Bind(
+            method,
+            Args("""{"name": "x", "cancellationToken": "anything"}""")
+        );
+
+        bound.ShouldBe(["x", CancellationToken.None]);
+    }
+
+    [Fact]
     public void Throws_on_null_method()
     {
         Should.Throw<ArgumentNullException>(() => JobArgumentBinder.Bind(null!, arguments: null));

--- a/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
@@ -62,9 +62,7 @@ public class JobCatalogTests
 
         var catalog = new JobCatalog(storage);
 
-        catalog
-            .ListToolsResult.Tools[0]
-            .Description.ShouldBe("Enqueue Hangfire job 'plain' (UndescribedJob.RunAsync).");
+        catalog.ListToolsResult.Tools[0].Description.ShouldBe("Enqueue Hangfire job 'plain'.");
     }
 
     [Fact]

--- a/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobCatalogTests.cs
@@ -62,7 +62,7 @@ public class JobCatalogTests
 
         var catalog = new JobCatalog(storage);
 
-        catalog.ListToolsResult.Tools[0].Description.ShouldBe("Enqueue Hangfire job 'plain'.");
+        catalog.ListToolsResult.Tools[0].Description.ShouldBe("Enqueue Hangfire job 'plain'");
     }
 
     [Fact]

--- a/tests/Nall.Hangfire.Mcp.Tests/JobInputSchemaTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/JobInputSchemaTests.cs
@@ -71,6 +71,39 @@ public class JobInputSchemaTests
     }
 
     [Fact]
+    public void Build_excludes_cancellation_token_parameter()
+    {
+        var method = typeof(CancellationTokenJob).GetMethod(nameof(CancellationTokenJob.RunAsync))!;
+
+        var schema = JobInputSchema.Build(method);
+        var doc = JsonDocument.Parse(schema.GetRawText()).RootElement;
+
+        var props = doc.GetProperty("properties");
+        props.TryGetProperty("name", out _).ShouldBeTrue();
+        props.TryGetProperty("cancellationToken", out _).ShouldBeFalse();
+
+        var required = doc.GetProperty("required")
+            .EnumerateArray()
+            .Select(e => e.GetString())
+            .ToArray();
+        required.ShouldBe(["name"]);
+    }
+
+    [Fact]
+    public void Build_emits_empty_schema_when_only_cancellation_token()
+    {
+        var method = typeof(CancellationTokenJob).GetMethod(
+            nameof(CancellationTokenJob.TokenOnlyAsync)
+        )!;
+
+        var schema = JobInputSchema.Build(method);
+        var doc = JsonDocument.Parse(schema.GetRawText()).RootElement;
+
+        doc.GetProperty("properties").EnumerateObject().ShouldBeEmpty();
+        doc.TryGetProperty("required", out _).ShouldBeFalse();
+    }
+
+    [Fact]
     public void Build_throws_on_null_method()
     {
         Should.Throw<ArgumentNullException>(() => JobInputSchema.Build(null!));

--- a/tests/Nall.Hangfire.Mcp.Tests/Maintenance/JobFilterMatcherTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Maintenance/JobFilterMatcherTests.cs
@@ -12,8 +12,9 @@ public class JobFilterMatcherTests
         string? queue = null,
         string? reason = null,
         string? exType = null,
-        string? exMsg = null
-    ) => new("id-1", job, queue, reason, exType, exMsg);
+        string? exMsg = null,
+        JobStateKind state = JobStateKind.Enqueued
+    ) => new("id-1", job, queue, reason, exType, exMsg, state);
 
     private static Job ReportJobInstance() =>
         new(

--- a/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceDispatcherTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Maintenance/MaintenanceDispatcherTests.cs
@@ -32,7 +32,10 @@ public class MaintenanceDispatcherTests
         var (_, d) = Setup();
         var r = d.Invoke(new CallToolRequestParams { Name = MaintenanceTools.GetStatistics });
         r.IsError.ShouldNotBe(true);
-        ResultJson(r).TryGetProperty("enqueued", out _).ShouldBeTrue();
+        var root = ResultJson(r);
+        root.GetProperty("counts").TryGetProperty("enqueued", out _).ShouldBeTrue();
+        root.TryGetProperty("now", out _).ShouldBeTrue();
+        root.TryGetProperty("trend24h", out _).ShouldBeTrue();
     }
 
     [Fact]

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
@@ -3,12 +3,12 @@
 Hangfire MCP capabilities (mindmap):
 
 - Maintenance tools
-  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage.
-  - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue.
-  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
-  - `hangfire_delete_job` — Move a single job to the Deleted state.
-  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs).
-  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
-  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage
+  - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue
+  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history
+  - `hangfire_delete_job` — Move a single job to the Deleted state
+  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs)
+  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize
+  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize
 - Run jobs (tools)
   - (no jobs discovered)

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_empty_catalog.verified.txt
@@ -3,8 +3,7 @@
 Hangfire MCP capabilities (mindmap):
 
 - Maintenance tools
-  - `hangfire_get_statistics` — Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.
-  - `hangfire_list_queues` — List Hangfire queues with their lengths and a sample of first enqueued jobs.
+  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage.
   - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue.
   - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
   - `hangfire_delete_job` — Move a single job to the Deleted state.

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -3,8 +3,7 @@
 Hangfire MCP capabilities (mindmap):
 
 - Maintenance tools
-  - `hangfire_get_statistics` — Return Hangfire global statistics: counts for Enqueued/Failed/Processing/Scheduled/Succeeded/Deleted/Recurring/Retries plus Servers and Queues.
-  - `hangfire_list_queues` — List Hangfire queues with their lengths and a sample of first enqueued jobs.
+  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage.
   - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue.
   - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
   - `hangfire_delete_job` — Move a single job to the Deleted state.
@@ -15,18 +14,18 @@ Hangfire MCP capabilities (mindmap):
   - `Run_DescribedJob_RunAsync` — Iface-level method description.
   - `Run_DirectlyDescribedJob_RunAsync` — Direct method description.
   - `Run_IEmailJob_SendAsync_1` — Send a transactional email to the given recipient.
-  - `Run_IEmailJob_SendAsync_2` — Enqueue Hangfire job 'IEmailJob_SendAsync_2' (IEmailJob.SendAsync).
-  - `Run_INotificationJob_BroadcastAsync` — Enqueue Hangfire job 'INotificationJob_BroadcastAsync' (INotificationJob.BroadcastAsync).
-  - `Run_IReportJob_PreviewAsync` — Enqueue Hangfire job 'IReportJob_PreviewAsync' (IReportJob.PreviewAsync).
-  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync' (MaintJob.RunAsync).
-  - `Run_MaintenanceJob_VacuumAsync` — Enqueue Hangfire job 'MaintenanceJob_VacuumAsync' (MaintenanceJob.VacuumAsync).
-  - `Run_NullableJob_RunAsync` — Enqueue Hangfire job 'NullableJob_RunAsync' (NullableJob.RunAsync).
+  - `Run_IEmailJob_SendAsync_2` — Enqueue Hangfire job 'IEmailJob_SendAsync_2'.
+  - `Run_INotificationJob_BroadcastAsync` — Enqueue Hangfire job 'INotificationJob_BroadcastAsync'.
+  - `Run_IReportJob_PreviewAsync` — Enqueue Hangfire job 'IReportJob_PreviewAsync'.
+  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync'.
+  - `Run_MaintenanceJob_VacuumAsync` — Enqueue Hangfire job 'MaintenanceJob_VacuumAsync'.
+  - `Run_NullableJob_RunAsync` — Enqueue Hangfire job 'NullableJob_RunAsync'.
   - `Run_ReportJob_GenerateAsync` — Generate the annual report.
-  - `Run_UndescribedJob_RunAsync` — Enqueue Hangfire job 'UndescribedJob_RunAsync' (UndescribedJob.RunAsync).
+  - `Run_UndescribedJob_RunAsync` — Enqueue Hangfire job 'UndescribedJob_RunAsync'.
   - `Run_data_export` — Export the named tables to the data lake in the requested format.
   - `Run_maint_rebuild-indexes` — Rebuild all indexes in the given PostgreSQL schema.
   - `Run_notify_dispatch` — Send a notification to a specific channel with an optional message and priority.
   - `Run_report_generate` — Generate the annual financial report and persist it to the report store.
-  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope' (ISendMessageJob.ExecuteAsync).
-  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text' (ISendMessageJob.ExecuteAsync).
-  - `Run_time_execute` — Enqueue Hangfire job 'time.execute' (ITimeJob.ExecuteAsync).
+  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope'.
+  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text'.
+  - `Run_time_execute` — Enqueue Hangfire job 'time.execute'.

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -12,21 +12,21 @@ Hangfire MCP capabilities (mindmap):
   - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
   - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
 - Run jobs (tools)
-  - `Run_time_execute` — Enqueue Hangfire job 'time.execute' (ITimeJob.ExecuteAsync).
-  - `Run_notify_dispatch` — Send a notification to a specific channel with an optional message and priority.
-  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text' (ISendMessageJob.ExecuteAsync).
-  - `Run_report_generate` — Generate the annual financial report and persist it to the report store.
-  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope' (ISendMessageJob.ExecuteAsync).
-  - `Run_data_export` — Export the named tables to the data lake in the requested format.
-  - `Run_maint_rebuild-indexes` — Rebuild all indexes in the given PostgreSQL schema.
   - `Run_DescribedJob_RunAsync` — Iface-level method description.
   - `Run_DirectlyDescribedJob_RunAsync` — Direct method description.
   - `Run_IEmailJob_SendAsync_1` — Send a transactional email to the given recipient.
   - `Run_IEmailJob_SendAsync_2` — Enqueue Hangfire job 'IEmailJob_SendAsync_2' (IEmailJob.SendAsync).
   - `Run_INotificationJob_BroadcastAsync` — Enqueue Hangfire job 'INotificationJob_BroadcastAsync' (INotificationJob.BroadcastAsync).
   - `Run_IReportJob_PreviewAsync` — Enqueue Hangfire job 'IReportJob_PreviewAsync' (IReportJob.PreviewAsync).
+  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync' (MaintJob.RunAsync).
   - `Run_MaintenanceJob_VacuumAsync` — Enqueue Hangfire job 'MaintenanceJob_VacuumAsync' (MaintenanceJob.VacuumAsync).
   - `Run_NullableJob_RunAsync` — Enqueue Hangfire job 'NullableJob_RunAsync' (NullableJob.RunAsync).
   - `Run_ReportJob_GenerateAsync` — Generate the annual report.
   - `Run_UndescribedJob_RunAsync` — Enqueue Hangfire job 'UndescribedJob_RunAsync' (UndescribedJob.RunAsync).
-  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync' (MaintJob.RunAsync).
+  - `Run_data_export` — Export the named tables to the data lake in the requested format.
+  - `Run_maint_rebuild-indexes` — Rebuild all indexes in the given PostgreSQL schema.
+  - `Run_notify_dispatch` — Send a notification to a specific channel with an optional message and priority.
+  - `Run_report_generate` — Generate the annual financial report and persist it to the report store.
+  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope' (ISendMessageJob.ExecuteAsync).
+  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text' (ISendMessageJob.ExecuteAsync).
+  - `Run_time_execute` — Enqueue Hangfire job 'time.execute' (ITimeJob.ExecuteAsync).

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_discover_with_jobs.verified.txt
@@ -3,29 +3,29 @@
 Hangfire MCP capabilities (mindmap):
 
 - Maintenance tools
-  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage.
-  - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue.
-  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history.
-  - `hangfire_delete_job` — Move a single job to the Deleted state.
-  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs).
-  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
-  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize.
+  - `hangfire_get_statistics` — Return Hangfire health snapshot: counters, last-24h trend (succeeded/failed), live servers (heartbeat, workers, queues), recent failure groups and ids in a configurable window. Use this as the entry point for triage
+  - `hangfire_list_jobs` — Page Hangfire jobs with optional state and filter. Omit 'state' to query across all states. Use this to discover ids before bulk delete/requeue
+  - `hangfire_get_job` — Return full details for a single Hangfire job: type, method, args, properties, and state history
+  - `hangfire_delete_job` — Move a single job to the Deleted state
+  - `hangfire_requeue_job` — Requeue a single job back to Enqueued (covers retry of Failed jobs)
+  - `hangfire_delete_jobs` — Bulk delete jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize
+  - `hangfire_requeue_jobs` — Bulk requeue jobs by explicit id list OR filter (exactly one). RECOMMENDED: pass dryRun:true first to preview matches before acting. Capped by MaintenanceMaxBulkSize
 - Run jobs (tools)
   - `Run_DescribedJob_RunAsync` — Iface-level method description.
   - `Run_DirectlyDescribedJob_RunAsync` — Direct method description.
   - `Run_IEmailJob_SendAsync_1` — Send a transactional email to the given recipient.
-  - `Run_IEmailJob_SendAsync_2` — Enqueue Hangfire job 'IEmailJob_SendAsync_2'.
-  - `Run_INotificationJob_BroadcastAsync` — Enqueue Hangfire job 'INotificationJob_BroadcastAsync'.
-  - `Run_IReportJob_PreviewAsync` — Enqueue Hangfire job 'IReportJob_PreviewAsync'.
-  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync'.
-  - `Run_MaintenanceJob_VacuumAsync` — Enqueue Hangfire job 'MaintenanceJob_VacuumAsync'.
-  - `Run_NullableJob_RunAsync` — Enqueue Hangfire job 'NullableJob_RunAsync'.
+  - `Run_IEmailJob_SendAsync_2` — Enqueue Hangfire job 'IEmailJob_SendAsync_2'
+  - `Run_INotificationJob_BroadcastAsync` — Enqueue Hangfire job 'INotificationJob_BroadcastAsync'
+  - `Run_IReportJob_PreviewAsync` — Enqueue Hangfire job 'IReportJob_PreviewAsync'
+  - `Run_MaintJob_RunAsync` — Enqueue Hangfire job 'MaintJob_RunAsync'
+  - `Run_MaintenanceJob_VacuumAsync` — Enqueue Hangfire job 'MaintenanceJob_VacuumAsync'
+  - `Run_NullableJob_RunAsync` — Enqueue Hangfire job 'NullableJob_RunAsync'
   - `Run_ReportJob_GenerateAsync` — Generate the annual report.
-  - `Run_UndescribedJob_RunAsync` — Enqueue Hangfire job 'UndescribedJob_RunAsync'.
+  - `Run_UndescribedJob_RunAsync` — Enqueue Hangfire job 'UndescribedJob_RunAsync'
   - `Run_data_export` — Export the named tables to the data lake in the requested format.
   - `Run_maint_rebuild-indexes` — Rebuild all indexes in the given PostgreSQL schema.
   - `Run_notify_dispatch` — Send a notification to a specific channel with an optional message and priority.
   - `Run_report_generate` — Generate the annual financial report and persist it to the report store.
-  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope'.
-  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text'.
-  - `Run_time_execute` — Enqueue Hangfire job 'time.execute'.
+  - `Run_send-message_envelope` — Enqueue Hangfire job 'send-message.envelope'
+  - `Run_send-message_text` — Enqueue Hangfire job 'send-message.text'
+  - `Run_time_execute` — Enqueue Hangfire job 'time.execute'

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_health_check.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_health_check.verified.txt
@@ -1,14 +1,12 @@
 ﻿description: Hangfire operational health summary.
 ---
-You are a Hangfire operations assistant. Produce a one-screen health report by following these steps:
+You are a Hangfire operations assistant. Produce a one-screen health report.
 
-1. Call tool `hangfire_get_statistics` to retrieve global counters.
-2. Call tool `hangfire_list_queues` to inspect per-queue lengths.
-3. Synthesize a structured report with these sections:
-   - **Backlog**: Enqueued + Scheduled totals; flag if any single queue length exceeds 1000.
-   - **Failures**: Failed count and Retries; flag if Failed > 50 or > 1% of Succeeded.
-   - **Throughput**: Processing count vs Servers; flag if Processing > 0 but Servers = 0.
-   - **Recurring**: Recurring count.
-   - **Verdict**: a single line — "Healthy", "Degraded", or "Unhealthy" — with the dominant reason.
+1. Call `hangfire_get_statistics` (single call gives counters, 24h trend, servers, recent failure groups).
+2. Synthesize:
+   - **Backlog**: Enqueued + Scheduled.
+   - **Failures**: Failed + failedInWindow; flag dominant failureGroups.
+   - **Throughput**: Processing vs servers.WorkersCount; flag Processing > 0 with no live servers.
+   - **Verdict**: one line — "Healthy" | "Degraded" | "Unhealthy" + dominant reason.
 
-Do not call any destructive tool (`hangfire_delete_*`, `hangfire_requeue_*`). This prompt is read-only.
+Read-only: do not call `hangfire_delete_*` or `hangfire_requeue_*`.

--- a/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_triage_failures.verified.txt
+++ b/tests/Nall.Hangfire.Mcp.Tests/Prompts/MaintenancePromptsTests.Render_triage_failures.verified.txt
@@ -1,14 +1,13 @@
 ﻿description: Triage Hangfire failure groups.
 ---
-You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend a remediation per failure group.
+You are a Hangfire failure-triage assistant. Investigate failed jobs and recommend remediation per failure group.
 
 Steps:
-1. Call `hangfire_list_jobs` with `state="Failed"`, `count=100`. Optionally narrow with `filter.jobType` if the user named a specific job.
-2. Group results by `(jobType, exceptionType, first 80 chars of exceptionMessage)`. Sort by group size descending.
-3. For each group, call `hangfire_get_job` on one representative id to fetch full state history.
-4. Classify each group:
-   - **Transient** (timeout, network, 5xx, deadlock) → recommend **requeue**.
-   - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → recommend **delete**.
-   - **Unknown** → recommend manual investigation, do not act.
-5. Present a markdown table: jobType | exception | count | recommendation | reasoning.
-6. SAFETY: Before any destructive action, you MUST first call `hangfire_delete_jobs` or `hangfire_requeue_jobs` with `dryRun=true` and the same filter, show the matched ids to the user, and explicitly ask for confirmation. Only call again with `dryRun=false` after the user confirms.
+1. Call `hangfire_get_statistics` — `failureGroups` already aggregates by (type, exception) with a sample id.
+2. For each group, call `hangfire_get_job` on the sample id for full state history. Narrow further with `hangfire_list_jobs` (state="Failed", filter.jobType / filter.exceptionContains / filter.since) only if needed.
+3. Classify:
+   - **Transient** (timeout, network, 5xx, deadlock) → **requeue**.
+   - **Poison** (deserialization, ArgumentException on stable input, 4xx with stable args) → **delete**.
+   - **Unknown** → manual investigation, do not act.
+4. Present a markdown table: jobType | exception | count | recommendation | reasoning.
+5. SAFETY: Before any destructive call, run `hangfire_delete_jobs`/`hangfire_requeue_jobs` with `dryRun=true` and the same filter, show matched ids, and wait for explicit user confirmation before calling again with `dryRun=false`.

--- a/tests/Nall.Hangfire.Mcp.Tests/Tools/McpToolsIntegrationTests.cs
+++ b/tests/Nall.Hangfire.Mcp.Tests/Tools/McpToolsIntegrationTests.cs
@@ -78,7 +78,6 @@ public class McpToolsIntegrationTests : IAsyncLifetime
 
         var names = tools.Select(t => t.Name).ToArray();
         names.ShouldContain("hangfire_get_statistics");
-        names.ShouldContain("hangfire_list_queues");
         names.ShouldContain("hangfire_list_jobs");
         names.ShouldContain("hangfire_get_job");
         names.ShouldContain("hangfire_delete_job");


### PR DESCRIPTION
## Summary
- **Source generator**: detects Hangfire wrappers by `Expression<TDelegate>` parameter shape (in addition to the known containing-type allowlist). Module-initializer registry call uses reflection so consumer assemblies aren't forced to compile-time reference `Nall.Hangfire.Mcp`.
- **CancellationToken support**: `JobInputSchema` and `JobArgumentBinder` skip `CancellationToken` parameters; the binder auto-supplies `CancellationToken.None`. New `JobParameterFilter` helper centralizes the check.
- **Maintenance**: `JobMatch` now carries `State` and `At` (timestamp). Dispatcher output surfaces both fields so callers can see job state without a second lookup.
- **Discover prompt**: tools are emitted in ordinal-sorted order for stable rendering.

## Test plan
- [x] `dotnet build hangfire-mcp-dotnet.slnx -p:WarningLevel=0 /clp:ErrorsOnly`
- [x] `dotnet test hangfire-mcp-dotnet.slnx --no-build` — 97/97 passing
- [x] New tests cover: CT auto-binding, CT excluded from schema, CT-only method, tool ordering snapshot